### PR TITLE
Re-enable dependabot alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Since we disabled #17 (by a force-push), we haven't enabled dependabot alerts. This PR re-enables dependabot alerts