### PR TITLE
Use binary for building docker image

### DIFF
--- a/.ci.yml
+++ b/.ci.yml
@@ -8,13 +8,12 @@ steps:
       - cargo build --verbose
       - cargo test --verbose
 
----
-kind: pipeline
-type: docker
-name: Docker Image
+  - name: build-docker-binary
+    image: rust
+    commands:
+      - cargo build --release
 
-steps:
-  - name: Push to Docker Hub
+  - name: push-docker-image
     image: plugins/docker
     settings:
       repo: terrabasedb/tdb

--- a/.ci.yml
+++ b/.ci.yml
@@ -12,6 +12,11 @@ steps:
     image: rust
     commands:
       - cargo build --release
+    when:
+      branch:
+        - next
+      event:
+        - tag
 
   - name: push-docker-image
     image: plugins/docker
@@ -22,3 +27,8 @@ steps:
       password:
         from_secret: docker_password
       auto_tag: true
+    when:
+      branch:
+        - next
+      event:
+        - tag

--- a/.ci.yml
+++ b/.ci.yml
@@ -13,10 +13,12 @@ steps:
     commands:
       - cargo build --release
     when:
-      branch:
-        - next
+      ref:
+        - refs/heads/next
+        - refs/tags/*
       event:
         - tag
+        - push
 
   - name: push-docker-image
     image: plugins/docker
@@ -28,7 +30,9 @@ steps:
         from_secret: docker_password
       auto_tag: true
     when:
-      branch:
-        - next
+      ref:
+        - refs/heads/next
+        - refs/tags/*
       event:
         - tag
+        - push

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Ignore deps in the target directory
+target/debug/deps/
+target/debug/incremental/
+target/debug/build/
+target/release/deps/
+target/release/incremental/
+target/release/build/
+target/doc/
+target/rls/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 # The Dockerfile for the TerrabaseDB server tdb
 #
 
-FROM rust:latest
+FROM debian:stable
+
 COPY target/release/tdb /usr/local/bin
 
 CMD ["tdb", "-h", "0.0.0.0", "-p", "2003"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,7 @@
 #
 
 FROM rust:latest
-RUN \
-    apt-get update && apt-get install git curl -y && \
-    cd /tmp && \
-    git clone https://github.com/terrabasedb/terrabasedb.git && \
-    cd terrabasedb && \
-    git checkout next && \
-    cargo test --release -p tdb && \
-    cargo build --release -p tdb && \
-    apt-get remove git curl -y && \
-    apt-get autoremove -y && \
-    cp -f target/release/tdb /usr/local/bin
+COPY target/release/tdb /usr/local/bin
 
 CMD ["tdb", "-h", "0.0.0.0", "-p", "2003"]
 


### PR DESCRIPTION
In the previous workflow, we were building and testing twice: once for the docker image and once for the test step. Now, we'll build a debug version in the test step, then build a release version and finally copy that into the docker image. This would heavily reduce our build times.

Related: #39 