### PR TITLE
Make sky-bench less aggressive

### DIFF
--- a/server/src/kvengine/jget.rs
+++ b/server/src/kvengine/jget.rs
@@ -76,13 +76,10 @@ mod json {
             self.0.push(b',');
         }
         pub fn finish(mut self) -> BuiltJSON {
-            *self
-                .0
-                .last_mut()
-                .unwrap_or_else(|| unsafe { 
-                    // UNSAFE(@ohsayan): There will always be a value corresponding to last_mut
-                    unreachable_unchecked() 
-                }) = b'}';
+            *self.0.last_mut().unwrap_or_else(|| unsafe {
+                // UNSAFE(@ohsayan): There will always be a value corresponding to last_mut
+                unreachable_unchecked()
+            }) = b'}';
             BuiltJSON(self.0)
         }
     }

--- a/server/src/queryengine/mod.rs
+++ b/server/src/queryengine/mod.rs
@@ -110,7 +110,7 @@ pub async fn execute_simple(db: &CoreDB, con: &mut Con<'_>, buf: ActionGroup) ->
 
 #[macro_export]
 /// A match generator macro built specifically for the `crate::queryengine::execute_simple` function
-/// 
+///
 /// **NOTE:** This macro needs _paths_ for both sides of the $x => $y, to produce something sensible
 macro_rules! gen_match {
     ($pre:ident, $db:ident, $con:ident, $buf:ident, $($x:path => $y:path),*) => {


### PR DESCRIPTION
Instead of unwrapping furiously right away, this commit makes sky-bench
first run a ping test (HEYA) to check if everything is all right.
If that is the case indeed, then we continue to run the benches, else
we terminate the program.

This has been discussed in #119 and will close #119