### PR TITLE
Revert "Re-enable dependabot alerts"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "11:00"
-  open-pull-requests-limit: 10


### PR DESCRIPTION
Reverts skytable/skytable#27 and closes #85. I've been going mad with dependabot alerts which are annoying and pointless. I'd rather do manual upgrades than use this :/