### PR TITLE
Change the data storage directory structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 /.vscode
 *.bin
+data
 /server/snapshots
 snapstore.bin
 snapstore.partmap

--- a/server/src/config/mod.rs
+++ b/server/src/config/mod.rs
@@ -26,6 +26,7 @@
 
 //! This module provides tools to handle configuration files and settings
 
+use crate::diskstore::snapshot::DIR_SNAPSHOT;
 #[cfg(test)]
 use libsky::TResult;
 use serde::Deserialize;
@@ -410,7 +411,7 @@ pub fn get_config_file_or_return_cfg() -> Result<ConfigType<ParsedConfig, PathBu
     let cfg_layout = load_yaml!("../cli.yml");
     let matches = App::from_yaml(cfg_layout).get_matches();
     let restorefile = matches.value_of("restore").map(|val| {
-        let mut path = PathBuf::from("snapshots/");
+        let mut path = PathBuf::from(DIR_SNAPSHOT);
         path.push(val);
         path
     });

--- a/server/src/config/mod.rs
+++ b/server/src/config/mod.rs
@@ -26,7 +26,6 @@
 
 //! This module provides tools to handle configuration files and settings
 
-use crate::diskstore::snapshot::DIR_SNAPSHOT;
 #[cfg(test)]
 use libsky::TResult;
 use serde::Deserialize;
@@ -36,7 +35,6 @@ use std::fs;
 #[cfg(test)]
 use std::net::Ipv6Addr;
 use std::net::{IpAddr, Ipv4Addr};
-use std::path::PathBuf;
 use toml;
 
 const DEFAULT_IPV4: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
@@ -407,14 +405,10 @@ impl fmt::Display for ConfigError {
 /// This parses a configuration file if it is supplied as a command line argument
 /// or it returns the default configuration. **If** the configuration file
 /// contains an error, then this returns it as an `Err` variant
-pub fn get_config_file_or_return_cfg() -> Result<ConfigType<ParsedConfig, PathBuf>, ConfigError> {
+pub fn get_config_file_or_return_cfg() -> Result<ConfigType<ParsedConfig, String>, ConfigError> {
     let cfg_layout = load_yaml!("../cli.yml");
     let matches = App::from_yaml(cfg_layout).get_matches();
-    let restorefile = matches.value_of("restore").map(|val| {
-        let mut path = PathBuf::from(DIR_SNAPSHOT);
-        path.push(val);
-        path
-    });
+    let restorefile = matches.value_of("restore").map(|v| v.to_string());
     // Check flags
     let sslonly = matches.is_present("sslonly");
     let noart = matches.is_present("noart");

--- a/server/src/coredb/mod.rs
+++ b/server/src/coredb/mod.rs
@@ -41,7 +41,6 @@ use parking_lot::RwLock;
 use parking_lot::RwLockReadGuard;
 use parking_lot::RwLockWriteGuard;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tokio;
 use tokio::sync::Notify;
@@ -285,9 +284,9 @@ impl CoreDB {
     pub fn new(
         bgsave: BGSave,
         snapshot_cfg: SnapshotConfig,
-        restore_file: Option<PathBuf>,
+        restore_file: Option<String>,
     ) -> TResult<(Self, Option<flock::FileLock>, flock::FileLock)> {
-        let coretable = diskstore::get_saved(restore_file)?;
+        let coretable = diskstore::get_snapshot(restore_file)?;
         let mut background_tasks: usize = 0;
         if !bgsave.is_disabled() {
             background_tasks += 1;

--- a/server/src/coredb/mod.rs
+++ b/server/src/coredb/mod.rs
@@ -286,7 +286,7 @@ impl CoreDB {
         snapshot_cfg: SnapshotConfig,
         restore_file: Option<String>,
     ) -> TResult<(Self, Option<flock::FileLock>, flock::FileLock)> {
-        let coretable = diskstore::get_snapshot(restore_file)?;
+        let coretable = diskstore::get_saved(restore_file)?;
         let mut background_tasks: usize = 0;
         if !bgsave.is_disabled() {
             background_tasks += 1;

--- a/server/src/coredb/mod.rs
+++ b/server/src/coredb/mod.rs
@@ -322,7 +322,7 @@ impl CoreDB {
             db.clone(),
             snapshot_cfg,
         ));
-        let lock = flock::FileLock::lock("data.bin")
+        let lock = flock::FileLock::lock(&*PERSIST_FILE)
             .map_err(|e| format!("Failed to acquire lock on data file with error '{}'", e))?;
         let cloned_descriptor = lock.try_clone()?;
         if bgsave.is_disabled() {

--- a/server/src/dbnet/mod.rs
+++ b/server/src/dbnet/mod.rs
@@ -53,7 +53,6 @@ use std::fs;
 use std::future::Future;
 use std::io::ErrorKind;
 use std::net::IpAddr;
-use std::path::PathBuf;
 use std::process;
 use std::sync::Arc;
 use tls::SslListener;
@@ -315,7 +314,7 @@ pub async fn run(
     bgsave_cfg: BGSave,
     snapshot_cfg: SnapshotConfig,
     sig: impl Future,
-    restore_filepath: Option<PathBuf>,
+    restore_filepath: Option<String>,
 ) -> (CoreDB, flock::FileLock) {
     let (signal, _) = broadcast::channel(1);
     let (terminate_tx, terminate_rx) = mpsc::channel(1);

--- a/server/src/dbnet/mod.rs
+++ b/server/src/dbnet/mod.rs
@@ -324,17 +324,7 @@ pub async fn run(
         Err(e) => match e.kind() {
             ErrorKind::AlreadyExists => (),
             _ => {
-                log::error!("Failed to create snapshot directories: '{}'", e);
-                process::exit(0x100);
-            }
-        },
-    }
-    match fs::create_dir("./data") {
-        Ok(_) => (),
-        Err(e) => match e.kind() {
-            ErrorKind::AlreadyExists => (),
-            _ => {
-                log::error!("Failed to create snapshot directories: '{}'", e);
+                log::error!("Failed to create data directories: '{}'", e);
                 process::exit(0x100);
             }
         },

--- a/server/src/diskstore/flock.rs
+++ b/server/src/diskstore/flock.rs
@@ -35,6 +35,7 @@ use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::Result;
 use std::io::Write;
+use std::path::PathBuf;
 
 #[derive(Debug)]
 /// # File Lock
@@ -63,12 +64,12 @@ impl FileLock {
     ///
     /// This function will create and lock a file if it doesn't exist or it
     /// will create and lock a new file
-    pub fn lock(filename: &str) -> Result<Self> {
+    pub fn lock(filename: impl Into<PathBuf>) -> Result<Self> {
         let file = OpenOptions::new()
             .create(true)
             .read(false)
             .write(true)
-            .open(filename)?;
+            .open(filename.into())?;
         Self::_lock(&file)?;
         Ok(Self {
             file,
@@ -128,7 +129,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_basic_file_lock() {
-        let mut file = FileLock::lock("data.bin").unwrap();
+        let mut file = FileLock::lock("datalock.bin").unwrap();
         file.write(&[1, 2, 3]).unwrap();
         file.unlock().unwrap();
     }

--- a/server/src/diskstore/mod.rs
+++ b/server/src/diskstore/mod.rs
@@ -54,73 +54,77 @@ lazy_static::lazy_static! {
     pub static ref OLD_PATH: PathBuf = PathBuf::from("./data.bin");
 }
 
-pub fn get_snapshot(path: Option<String>) -> TResult<Option<HashMap<String, Data>>> {
-    if let Some(path) = path {
-        // the path just has the snapshot name, let's improve that
-        let mut snap_location = PathBuf::from(DIR_SNAPSHOT);
-        snap_location.push(path);
-        let file = match fs::read(snap_location) {
-            Ok(f) => f,
-            Err(e) => match e.kind() {
-                ErrorKind::NotFound => {
-                    // Probably the old snapshot directory?
-                    match fs::read(DIR_OLD_SNAPSHOT) {
-                        Ok(f) => f,
-                        _ => return Err(e.into()),
-                    }
-                }
-                _ => return Err(e.into()),
-            },
-        };
-        let parsed = deserialize(file)?;
-        Ok(Some(parsed))
-    } else {
-        Ok(None)
-    }
-}
-
-/// Try to get the saved data from disk. This returns `None`, if the `data/data.bin` wasn't found
-/// otherwise the `data/data.bin` file is deserialized and parsed into a `HashMap`
-pub fn get_saved() -> TResult<Option<HashMap<String, Data>>> {
-    let file = match fs::read(&*PERSIST_FILE) {
+fn get_snapshot(path: String) -> TResult<Option<HashMap<String, Data>>> {
+    // the path just has the snapshot name, let's improve that
+    let mut snap_location = PathBuf::from(DIR_SNAPSHOT);
+    snap_location.push(path);
+    let file = match fs::read(snap_location) {
         Ok(f) => f,
         Err(e) => match e.kind() {
             ErrorKind::NotFound => {
-                // TODO(@ohsayan): Drop support for this in the future
-                // This might be an old installation still not using the data/data.bin path
-                match fs::read(OLD_PATH.to_path_buf()) {
-                    Ok(f) => {
-                        log::warn!("Your data file was found to be in the current directory and not in data/data.bin");
-                        if let Err(e) = fs::rename("data.bin", "data/data.bin") {
-                            log::error!("Failed to move data.bin into data/data.bin directory. Consider moving it manually");
-                            return Err(format!(
-                                "Failed to move data.bin into data/data.bin: {}",
-                                e
-                            )
-                            .into());
-                        } else {
-                            log::info!("The data file has been moved into the new directory");
-                            log::warn!("This backwards compat directory support will be removed in the future");
-                        }
-                        f
-                    }
-                    Err(e) => match e.kind() {
-                        ErrorKind::NotFound => return Ok(None),
-                        _ => {
-                            return Err(
-                                format!("Coudln't read flushed data from disk: {}", e).into()
-                            )
-                        }
-                    },
+                // Probably the old snapshot directory?
+                match fs::read(DIR_OLD_SNAPSHOT) {
+                    Ok(f) => f,
+                    _ => return Err(e.into()),
                 }
             }
-            _ => return Err(format!("Couldn't read flushed data from disk: {}", e).into()),
+            _ => return Err(e.into()),
         },
     };
     let parsed = deserialize(file)?;
     Ok(Some(parsed))
 }
 
+/// Try to get the saved data from disk. This returns `None`, if the `data/data.bin` wasn't found
+/// otherwise the `data/data.bin` file is deserialized and parsed into a `HashMap`
+pub fn get_saved(path: Option<String>) -> TResult<Option<HashMap<String, Data>>> {
+    if let Some(path) = path {
+        get_snapshot(path)
+    } else {
+        let file = match fs::read(&*PERSIST_FILE) {
+            Ok(f) => f,
+            Err(e) => match e.kind() {
+                ErrorKind::NotFound => {
+                    // TODO(@ohsayan): Drop support for this in the future
+                    // This might be an old installation still not using the data/data.bin path
+                    match fs::read(OLD_PATH.to_path_buf()) {
+                        Ok(f) => {
+                            log::warn!("Your data file was found to be in the current directory and not in data/data.bin");
+                            if let Err(e) = fs::rename("data.bin", "data/data.bin") {
+                                log::error!("Failed to move data.bin into data/data.bin directory. Consider moving it manually");
+                                return Err(format!(
+                                    "Failed to move data.bin into data/data.bin: {}",
+                                    e
+                                )
+                                .into());
+                            } else {
+                                log::info!("The data file has been moved into the new directory");
+                                log::warn!("This backwards compat directory support will be removed in the future");
+                            }
+                            f
+                        }
+                        Err(e) => match e.kind() {
+                            ErrorKind::NotFound => return Ok(None),
+                            _ => {
+                                return Err(
+                                    format!("Coudln't read flushed data from disk: {}", e).into()
+                                )
+                            }
+                        },
+                    }
+                }
+                _ => return Err(format!("Couldn't read flushed data from disk: {}", e).into()),
+            },
+        };
+        let parsed = deserialize(file)?;
+        Ok(Some(parsed))
+    }
+}
+
+#[cfg(test)]
+pub fn test_deserialize(file: Vec<u8>) -> TResult<HashMap<String, Data>> {
+    deserialize(file)
+}
 fn deserialize(file: Vec<u8>) -> TResult<HashMap<String, Data>> {
     let parsed: DiskStoreFromDisk = bincode::deserialize(&file)?;
     let parsed: HashMap<String, Data> = HashMap::from_iter(

--- a/server/src/diskstore/snapshot.rs
+++ b/server/src/diskstore/snapshot.rs
@@ -247,7 +247,7 @@ fn test_snapshot() {
     let mut snapengine = SnapshotEngine::new(4, &db, Some(&ourdir)).unwrap();
     let _ = snapengine.mksnap();
     let current = snapengine.get_snapshots().next().unwrap();
-    let read_hmap = fs::read(PathBuf::from(current)).unwrap();
+    let read_hmap = diskstore::test_deserialize(fs::read(PathBuf::from(current)).unwrap()).unwrap();
     let dbhmap = db.get_hashmap_deep_clone();
     assert_eq!(read_hmap, dbhmap);
     snapengine.clearall().unwrap();

--- a/server/src/diskstore/snapshot.rs
+++ b/server/src/diskstore/snapshot.rs
@@ -46,13 +46,13 @@ lazy_static::lazy_static! {
     /// ```
     static ref SNAP_MATCH: Regex = Regex::new("^\\d{4}(0[1-9]|1[012])(0[1-9]|[12][0-9]|3[01])(-)(?:(?:([01]?\\d|2[0-3]))?([0-5]?\\d))?([0-5]?\\d)(.snapshot)$").unwrap();
     /// The directory for remote snapshots
-    pub static ref DIR_REMOTE_SNAPSHOT: PathBuf = PathBuf::from("./snapshots/remote");
+    pub static ref DIR_REMOTE_SNAPSHOT: PathBuf = PathBuf::from("./data/snapshots/remote");
 }
 
 /// The default snapshot directory
 ///
 /// This is currently a `snapshot` directory under the current directory
-pub const DIR_SNAPSHOT: &'static str = "snapshots";
+pub const DIR_SNAPSHOT: &'static str = "data/snapshots";
 /// The default snapshot count is 12, assuming that the user would take a snapshot
 /// every 2 hours (or 7200 seconds)
 const DEF_SNAPSHOT_COUNT: usize = 12;

--- a/server/src/diskstore/snapshot.rs
+++ b/server/src/diskstore/snapshot.rs
@@ -53,6 +53,7 @@ lazy_static::lazy_static! {
 ///
 /// This is currently a `snapshot` directory under the current directory
 pub const DIR_SNAPSHOT: &'static str = "data/snapshots";
+pub const DIR_OLD_SNAPSHOT: &'static str = "snapshots";
 /// The default snapshot count is 12, assuming that the user would take a snapshot
 /// every 2 hours (or 7200 seconds)
 const DEF_SNAPSHOT_COUNT: usize = 12;
@@ -246,9 +247,7 @@ fn test_snapshot() {
     let mut snapengine = SnapshotEngine::new(4, &db, Some(&ourdir)).unwrap();
     let _ = snapengine.mksnap();
     let current = snapengine.get_snapshots().next().unwrap();
-    let read_hmap = diskstore::get_saved(Some(PathBuf::from(current)))
-        .unwrap()
-        .unwrap();
+    let read_hmap = fs::read(PathBuf::from(current)).unwrap();
     let dbhmap = db.get_hashmap_deep_clone();
     assert_eq!(read_hmap, dbhmap);
     snapengine.clearall().unwrap();
@@ -328,6 +327,7 @@ mod queue {
     //!
     //! This implementation is specifically built for use with the snapshotting utility
     use std::path::PathBuf;
+    #[cfg(test)]
     use std::slice::Iter;
     #[derive(Debug, PartialEq)]
     pub struct Queue {
@@ -368,6 +368,7 @@ mod queue {
                 x
             }
         }
+        #[cfg(test)]
         /// Returns an iterator over the slice of strings
         pub fn iter(&self) -> Iter<PathBuf> {
             self.queue.iter()

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -128,7 +128,7 @@ async fn check_args_and_get_cfg() -> (
     PortConfig,
     BGSave,
     SnapshotConfig,
-    Option<std::path::PathBuf>,
+    Option<String>,
 ) {
     let cfg = config::get_config_file_or_return_cfg();
     let binding_and_cfg = match cfg {


### PR DESCRIPTION
Previously our data storage directory structure looked like:
```
.
|__other-user-files
|__data.bin
|__snapshots
    |__DDMMYY-HHMMSS.snapshot (many)
    |__remote
         |__remotesnap.snapshot (many)
```

This PR changes this structure to:
```
|__other-user-files
|__data
    |__data.bin
    |__snapshots
        |__DDMMYY-HHMMSS.snapshot (many)
        |__remote
            |__remotesnap.snapshot (many)
```

This PR also:
- provides backwards compatibility for the data file and snapshots created earlier
- fixes snapshot directory parsing logic