### PR TITLE
Fix background services

### DIFF
--- a/server/src/coredb/mod.rs
+++ b/server/src/coredb/mod.rs
@@ -26,7 +26,6 @@
 
 //! # The core database engine
 
-use crate::config::BGSave;
 use crate::config::SnapshotConfig;
 use crate::config::SnapshotPref;
 use crate::coredb::htable::HTable;
@@ -42,9 +41,7 @@ use parking_lot::RwLock;
 use parking_lot::RwLockReadGuard;
 use parking_lot::RwLockWriteGuard;
 use std::sync::Arc;
-use tokio;
 pub mod htable;
-use tokio::sync::Notify;
 
 #[macro_export]
 macro_rules! flush_db {
@@ -63,16 +60,6 @@ pub struct CoreDB {
     /// The shared object, which contains a `Shared` object wrapped in a thread-safe
     /// RC
     pub shared: Arc<Shared>,
-    /// The number of background tasks that should be expected
-    ///
-    /// This is used by the `Drop` implementation to avoid killing the database in the event
-    /// that a background service is still working. The calculation is pretty straightforward:
-    /// ```text
-    /// 1 (for the current process) + if bgsave is running + if snapshotting is enabled
-    /// ```
-    /// This should **not be changed** during runtime, and should only be initialized when `CoreDB`
-    /// is first initialized
-    background_tasks: usize,
     /// The number of snapshots that are to be kept at the most
     ///
     /// If this is set to Some(0), then all the snapshots will be kept. Otherwise, if it is set to
@@ -124,11 +111,6 @@ impl SnapshotStatus {
 /// A shared _state_
 #[derive(Debug)]
 pub struct Shared {
-    /// This is used by the `BGSAVE` task. `Notify` is used to signal a task
-    /// to wake up
-    pub bgsave_task: Notify,
-    /// The snapshot service notifier
-    pub snapshot_service: Notify,
     /// A `Coretable` wrapped in a R/W lock
     pub table: RwLock<Coretable>,
 }
@@ -137,15 +119,10 @@ impl Shared {
     /// This task performs a `sync`hronous background save operation
     ///
     /// It runs BGSAVE and then returns control to the caller. The caller is responsible
-    /// for periodically calling BGSAVE. This returns `false`, **if** the database
-    /// is shutting down. Otherwise `true` is returned
-    pub fn run_bgsave(&self, file: &mut flock::FileLock) -> bool {
+    /// for periodically calling BGSAVE
+    pub fn run_bgsave(&self, file: &mut flock::FileLock) {
         log::trace!("BGSAVE started");
         let rlock = self.table.read();
-        if rlock.terminate {
-            drop(rlock);
-            return false;
-        }
         // Kick in BGSAVE
         match diskstore::flush_data(file, rlock.get_ref()) {
             Ok(_) => {
@@ -156,10 +133,8 @@ impl Shared {
                     self.table.write().poisoned = false;
                 }
                 log::info!("BGSAVE completed successfully");
-                return true;
             }
             Err(e) => {
-                // IMPORTANT! Drop the read lock first fella!
                 drop(rlock);
                 // IMPORTANT! POISON THE DATABASE, NO MORE WRITES FOR YOU!
                 {
@@ -167,25 +142,16 @@ impl Shared {
                     self.table.write().poisoned = true;
                 }
                 log::error!("BGSAVE failed with error: '{}'", e);
-                return false;
             }
         }
-    }
-    /// Check if the server has received a termination signal
-    pub fn is_termsig(&self) -> bool {
-        self.table.read().terminate
     }
 }
 
 /// The `Coretable` holds all the key-value pairs in a `HTable`
-/// and the `terminate` field, which when set to true will cause all other
-/// background tasks to terminate
 #[derive(Debug)]
 pub struct Coretable {
     /// The core table contain key-value pairs
     coremap: HTable<String, Data>,
-    /// The termination signal flag
-    pub terminate: bool,
     /// Whether the database is poisoned or not
     ///
     /// If the database is poisoned -> the database can no longer accept writes
@@ -243,7 +209,6 @@ impl CoreDB {
             println!("{:#?}", self.acquire_read());
         }
     }
-    
     pub fn poison(&self) {
         (*self.shared).table.write().poisoned = true;
     }
@@ -269,25 +234,6 @@ impl CoreDB {
         (*self.snapcfg).as_ref().unwrap().unlock_snap();
     }
 
-    /// Returns the expected `Arc::strong_count` for the `CoreDB` object when it is about to be dropped
-    ///
-    /// This is the deal:
-    /// 1. Runtime starts
-    /// 2. [`dbnet::run`] creates a coredb, so strong count is 1
-    /// 4. [`coredb::CoreDB::new()`] spawns the background task who's count we have here, so strong count is 2/3
-    /// 3. [`dbnet::run`] distributes clones to listeners, so strong count is either 4/5
-    /// 4. Listeners further distributed clones per-stream, so strong count can potentially cross 50000 (semaphore)
-    /// 5. Now all workers terminate and we should be back to a strong count of 2/3
-    ///
-    /// Step 5 is where CoreDB should notify the background services to stop. So, at step 5 we have this ingenious
-    /// listener who should tell the services to terminate. At this point, our listener itself holds an atomic
-    /// reference, the [`dbnet::run`] holds one and the background tasks hold some. So there should be:
-    /// `background_tasks + 2` number of atomic references when we should signal a quit; in other words, this
-    /// the last active listener who is about to bring down the server xD
-    pub const fn expected_strong_count_at_drop(&self) -> usize {
-        self.background_tasks + 2
-    }
-
     /// Execute a query that has already been validated by `Connection::read_query`
     pub async fn execute_query<T, Strm>(&self, query: Query, con: &mut T) -> TResult<()>
     where
@@ -310,69 +256,39 @@ impl CoreDB {
     ///
     /// This also checks if a local backup of previously saved data is available.
     /// If it is - it restores the data. Otherwise it creates a new in-memory table
-    pub fn new(
-        bgsave: BGSave,
-        snapshot_cfg: SnapshotConfig,
-        restore_file: Option<String>,
-    ) -> TResult<(Self, Option<flock::FileLock>)> {
+    pub fn new(snapshot_cfg: &SnapshotConfig, restore_file: Option<String>) -> TResult<Self> {
         let coretable = diskstore::get_saved(restore_file)?;
-        let mut background_tasks: usize = 0;
-        if !bgsave.is_disabled() {
-            background_tasks += 1;
-        }
         let mut snap_count = None;
         if let SnapshotConfig::Enabled(SnapshotPref { every: _, atmost }) = snapshot_cfg {
-            background_tasks += 1;
             snap_count = Some(atmost);
         }
         let snapcfg = snap_count
-            .map(|max| Arc::new(Some(SnapshotStatus::new(max))))
+            .map(|max| Arc::new(Some(SnapshotStatus::new(*max))))
             .unwrap_or(Arc::new(None));
         let db = if let Some(coretable) = coretable {
             CoreDB {
                 shared: Arc::new(Shared {
-                    bgsave_task: Notify::new(),
                     table: RwLock::new(Coretable {
                         coremap: coretable,
-                        terminate: false,
                         poisoned: false,
                     }),
-                    snapshot_service: Notify::new(),
                 }),
-                background_tasks,
                 snapcfg,
             }
         } else {
-            CoreDB::new_empty(background_tasks, snapcfg)
+            CoreDB::new_empty(snapcfg)
         };
-        // Spawn the snapshot service in a separate task
-        tokio::spawn(diskstore::snapshot::snapshot_service(
-            db.clone(),
-            snapshot_cfg,
-        ));
-        let lock = flock::FileLock::lock(&*PERSIST_FILE)
-            .map_err(|e| format!("Failed to acquire lock on data file with error '{}'", e))?;
-        if bgsave.is_disabled() {
-            Ok((db, Some(lock)))
-        } else {
-            // Spawn the BGSAVE service in a separate task
-            tokio::spawn(diskstore::bgsave_scheduler(db.clone(), bgsave, lock));
-            Ok((db, None))
-        }
+        Ok(db)
     }
     /// Create an empty in-memory table
-    pub fn new_empty(background_tasks: usize, snapcfg: Arc<Option<SnapshotStatus>>) -> Self {
+    pub fn new_empty(snapcfg: Arc<Option<SnapshotStatus>>) -> Self {
         CoreDB {
             shared: Arc::new(Shared {
-                bgsave_task: Notify::new(),
                 table: RwLock::new(Coretable {
                     coremap: HTable::<String, Data>::new(),
-                    terminate: false,
                     poisoned: false,
                 }),
-                snapshot_service: Notify::new(),
             }),
-            background_tasks,
             snapcfg,
         }
     }
@@ -415,23 +331,5 @@ impl CoreDB {
     /// can be used by test functions and the server, but **use with caution!**
     pub fn get_htable_deep_clone(&self) -> HTable<String, Data> {
         (*self.acquire_read().get_ref()).clone()
-    }
-}
-
-impl Drop for CoreDB {
-    fn drop(&mut self) {
-        // If the strong count is equal to the `expected_strong_count_at_drop()`
-        // then the background services are still running, so tell them to terminate
-        if Arc::strong_count(&self.shared) == self.expected_strong_count_at_drop() {
-            // Acquire a lock to prevent anyone from writing something
-            let mut coretable = self.shared.table.write();
-            coretable.terminate = true;
-            // Drop the write lock first to avoid BGSAVE ending up in failing
-            // to get a read lock
-            drop(coretable);
-            // Notify the background tasks to quit
-            self.shared.bgsave_task.notify_one();
-            self.shared.snapshot_service.notify_one();
-        }
     }
 }

--- a/server/src/coredb/mod.rs
+++ b/server/src/coredb/mod.rs
@@ -243,6 +243,10 @@ impl CoreDB {
             println!("{:#?}", self.acquire_read());
         }
     }
+    
+    pub fn poison(&self) {
+        (*self.shared).table.write().poisoned = true;
+    }
 
     /// Check if snapshotting is enabled
     pub fn is_snapshot_enabled(&self) -> bool {

--- a/server/src/diskstore/flock.rs
+++ b/server/src/diskstore/flock.rs
@@ -153,12 +153,12 @@ mod tests {
         // this will truncate the entire previous file and write 4, 5, 6
         cloned.write(&[4, 5, 6]).unwrap();
         drop(cloned);
-        // this will again truncate the entire previous file and write 7, 8, 9
-        file.write(&[7, 8, 9]).unwrap();
+        // this will again truncate the entire previous file and write 7, 8
+        file.write(&[7, 8]).unwrap();
         drop(file);
         let res = std::fs::read("data5.bin").unwrap();
-        // hence ultimately we'll have 7, 8, 9
-        assert_eq!(res, vec![7, 8, 9]);
+        // hence ultimately we'll have 7, 8
+        assert_eq!(res, vec![7, 8]);
     }
 }
 

--- a/server/src/diskstore/flock.rs
+++ b/server/src/diskstore/flock.rs
@@ -177,8 +177,9 @@ mod __sys {
     use std::io::{Error, Result};
     use std::mem;
     use std::os::windows::io::AsRawHandle;
+    use std::os::windows::io::FromRawHandle;
     use std::ptr;
-    use winapi::shared::minwindef::DWORD;
+    use winapi::shared::minwindef::{BOOL, DWORD};
     use winapi::um::fileapi::{LockFileEx, UnlockFile};
     use winapi::um::handleapi::DuplicateHandle;
     use winapi::um::minwinbase::{LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY};

--- a/server/src/diskstore/flock.rs
+++ b/server/src/diskstore/flock.rs
@@ -109,18 +109,6 @@ impl FileLock {
     }
 }
 
-impl Drop for FileLock {
-    fn drop(&mut self) {
-        // If the file isn't unlocked already, attempt to unlock it
-        if !self.unlocked {
-            if self.unlock().is_err() {
-                // This is wild; uh, oh
-                panic!("Failed to unlock file when dropping value");
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/server/src/diskstore/flock.rs
+++ b/server/src/diskstore/flock.rs
@@ -98,6 +98,12 @@ impl FileLock {
         // Now write to the file
         self.file.write_all(bytes)
     }
+    pub fn try_clone(&self) -> Result<Self> {
+        Ok(FileLock {
+            file: self.file.try_clone()?,
+            unlocked: self.unlocked,
+        })
+    }
 }
 
 impl Drop for FileLock {

--- a/server/src/diskstore/flock.rs
+++ b/server/src/diskstore/flock.rs
@@ -84,6 +84,11 @@ impl FileLock {
     fn _lock(file: &File) -> Result<()> {
         __sys::try_lock_ex(file)
     }
+    pub fn relock(&mut self) -> Result<()> {
+        __sys::try_lock_ex(&self.file)?;
+        self.unlocked = false;
+        Ok(())
+    }
     /// Unlock the file
     ///
     /// This sets the `unlocked` flag to true

--- a/server/src/diskstore/mod.rs
+++ b/server/src/diskstore/mod.rs
@@ -198,16 +198,16 @@ pub async fn bgsave_scheduler(
             // his data - which is good! So we'll turn this into a `Duration`
             let duration = Duration::from_secs(duration);
             while !handle.shared.is_termsig() {
-                if handle.shared.run_bgsave(&mut file) {
-                    tokio::select! {
-                        // Sleep until `duration` from the current time instant
-                        _ = time::sleep_until(time::Instant::now() + duration) => {}
-                        // Otherwise wait for a notification
-                        _ = handle.shared.bgsave_task.notified() => {
-                            println!("Told to quit");
-                            // we got a notification to quit; so break out
-                            break;
-                        }
+                tokio::select! {
+                    // Sleep until `duration` from the current time instant
+                    _ = time::sleep_until(time::Instant::now() + duration) => {
+                        if !handle.shared.run_bgsave(&mut file) {break;}
+                    }
+                    // Otherwise wait for a notification
+                    _ = handle.shared.bgsave_task.notified() => {
+                        println!("Told to quit");
+                        // we got a notification to quit; so break out
+                        break;
                     }
                 }
             }

--- a/server/src/diskstore/mod.rs
+++ b/server/src/diskstore/mod.rs
@@ -205,7 +205,6 @@ pub async fn bgsave_scheduler(
                     }
                     // Otherwise wait for a notification
                     _ = handle.shared.bgsave_task.notified() => {
-                        println!("Told to quit");
                         // we got a notification to quit; so break out
                         break;
                     }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -114,7 +114,15 @@ fn main() {
     } else {
         log::info!("Successfully saved data to disk");
     }
-    terminal::write_info("Goodbye :)\n").unwrap();
+    if let Err(e) = lock.unlock() {
+        log::error!(
+            "Failed to unlock data file even after successfully saving data: {}",
+            e
+        );
+        std::process::exit(0x100);
+    } else {
+        terminal::write_info("Goodbye :)\n").unwrap();
+    }
 }
 
 /// This function checks the command line arguments and either returns a config object

--- a/server/src/tests/mod.rs
+++ b/server/src/tests/mod.rs
@@ -49,19 +49,23 @@ mod bgsave {
         let DUR_WITH_EPSILON: Duration = Duration::from_millis(1500) + Duration::from_secs(10);
         let (signal, _) = broadcast::channel(1);
         let datahandle = CoreDB::new_empty(Arc::new(None));
-        let flock = diskstore::flock::FileLock::lock("bgsave_test_1.bin").unwrap();
+        let mut flock = diskstore::flock::FileLock::lock("bgsave_test_1.bin").unwrap();
         let bgsave_configuration = BGSave::Enabled(10);
         let handle = tokio::spawn(diskstore::bgsave_scheduler(
             datahandle.clone(),
             bgsave_configuration,
-            flock,
+            flock.try_clone().unwrap(),
             Terminator::new(signal.subscribe()),
         ));
         // sleep for 10 seconds with epsilon 1.5s
         time::sleep(DUR_WITH_EPSILON).await;
+        // temporarily unlock the the file
+        flock.unlock().unwrap();
         // we should get an empty map
         let saved = diskstore::test_deserialize(fs::read("bgsave_test_1.bin").unwrap()).unwrap();
         assert!(saved.len() == 0);
+        // now relock the file
+        flock.relock().unwrap();
         // now let's quickly write some data
         {
             datahandle.acquire_write().unwrap().get_mut_ref().insert(
@@ -72,20 +76,24 @@ mod bgsave {
         // sleep for 10 seconds with epsilon 1.5s
         time::sleep(DUR_WITH_EPSILON).await;
         // we should get a map with the one key
+        flock.unlock().unwrap();
         let saved = diskstore::test_deserialize(fs::read("bgsave_test_1.bin").unwrap()).unwrap();
         assert_eq!(saved, map_should_be_with_one);
+        flock.relock().unwrap();
         // now let's remove all the data
         {
             datahandle.acquire_write().unwrap().get_mut_ref().clear();
         }
         // sleep for 10 seconds with epsilon 1.5s
         time::sleep(DUR_WITH_EPSILON).await;
+        flock.unlock().unwrap();
         let saved = diskstore::test_deserialize(fs::read("bgsave_test_1.bin").unwrap()).unwrap();
         assert!(saved.len() == 0);
-
+        flock.relock().unwrap();
         // drop the signal; all waiting tasks can now terminate
         drop(signal);
         handle.await.unwrap().unlock().unwrap();
+        drop(flock);
         // check the file again after unlocking
         let saved = diskstore::test_deserialize(fs::read("bgsave_test_1.bin").unwrap()).unwrap();
         assert!(saved.len() == 0);


### PR DESCRIPTION
This PR will fix a multitude of problems associated with background services that Skytable uses. All the details are provided in the commit messages.

**TL;DR** The following things were fixed: 
- BGSAVE wasn't guaranteed to unlock the file
- There was a bug in the file truncate operation
- BGSAVE ran immediately after launch; this was unnecessary
- Snapshots ran immediately after launch; this was unnecessary
- Both BGSAVE and the snapshot services are blocking in nature and were run in async, non compute-intensive tasks (should have been on a dedicated blocking thread)
