### PR TITLE
Migrate to using `Coremap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if",
+ "num_cpus",
+ "serde",
+]
+
+[[package]]
 name = "devtimer"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +841,7 @@ dependencies = [
  "cc",
  "chrono",
  "clap",
+ "dashmap",
  "env_logger",
  "jemallocator",
  "lazy_static",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,6 +12,7 @@ libsky = { path = "../libsky" }
 bincode = "1.3.3"
 parking_lot = "0.11.1"
 lazy_static = "1.4.0"
+dashmap = {version = "4.0.2", features = ["serde"]}
 serde_derive = "1.0.126"
 serde = { version = "1.0.126", features = ["derive"] }
 toml = "0.5.8"

--- a/server/src/compat/mod.rs
+++ b/server/src/compat/mod.rs
@@ -121,7 +121,7 @@ fn upgrade_file(src: impl Into<PathBuf>, destination: impl Into<PathBuf>) -> TRe
             .into_iter()
             .map(|(key, value)| (Data::from_string(key), value)),
     );
-    let data_in_new_format = bincode::serialize(&data_in_new_format)?;
+    let data_in_new_format = data_in_new_format.serialize()?;
     let destination = destination.into();
     let mut file = fs::File::create(&destination)?;
     log::info!("Writing upgraded file to {}", destination.to_string_lossy());

--- a/server/src/coredb/htable.rs
+++ b/server/src/coredb/htable.rs
@@ -25,44 +25,188 @@
 */
 
 use bytes::Bytes;
+use dashmap::iter::Iter;
+use dashmap::mapref::entry::Entry;
+use dashmap::mapref::one::Ref;
+use dashmap::DashMap;
+use libsky::TResult;
+use parking_lot::Condvar;
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
-pub use std::collections::hash_map::Entry;
-use std::collections::hash_map::Keys;
-use std::collections::hash_map::Values;
-use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
 use std::iter::FromIterator;
+use std::marker::PhantomData;
 use std::ops::Deref;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct HTable<K, V>
+pub type HashTable<K, V> = DashMap<K, V>;
+
+use std::sync::Arc;
+
+const ORDERING_RELAXED: Ordering = Ordering::Relaxed;
+
+#[derive(Debug, Clone)]
+pub struct HTable<K: Eq + Hash, V>
 where
     K: Eq + Hash,
 {
-    inner: HashMap<K, V>,
+    inner: Arc<Coremap<K, V>>,
+    _marker_key: PhantomData<K>,
+    _marker_value: PhantomData<V>,
 }
 
-impl<K, V> HTable<K, V>
+impl<K: Eq + Hash + Clone + Serialize, V: Clone + Serialize> HTable<K, V> {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Coremap::new()),
+            _marker_key: PhantomData,
+            _marker_value: PhantomData,
+        }
+    }
+    pub fn from_raw(inner: Coremap<K, V>) -> Self {
+        Self {
+            inner: Arc::new(inner),
+            _marker_key: PhantomData,
+            _marker_value: PhantomData,
+        }
+    }
+}
+
+/// A [`CVar`] is a conditional variable that uses zero CPU time while waiting on a condition
+///
+/// This Condvar was specifically built for use with [`Coremap`] which uses a [`TableLockstateGuard`]
+/// object to temporarily deny all writes
+#[derive(Debug)]
+struct Cvar {
+    c: Condvar,
+    m: Mutex<()>,
+}
+
+impl Cvar {
+    fn new() -> Self {
+        Self {
+            c: Condvar::new(),
+            m: Mutex::new(()),
+        }
+    }
+    /// Notify all the threads waiting on this condvar that the state has changed
+    fn notify_all(&self) {
+        let _ = self.c.notify_all();
+    }
+    /// Wait for a notification on the conditional variable
+    fn wait(&self, locked_state: &AtomicBool) {
+        while locked_state.load(ORDERING_RELAXED) {
+            // only wait if locked_state is true
+            let guard = self.m.lock();
+            let mut owned_guard = guard;
+            self.c.wait(&mut owned_guard);
+        }
+    }
+    fn wait_and_then_immediately<T, F>(&self, locked_state: &AtomicBool, and_then: F) -> T
+    where
+        F: Fn() -> T,
+    {
+        while locked_state.load(ORDERING_RELAXED) {
+            // only wait if locked_state is true
+            let guard = self.m.lock();
+            let mut owned_guard = guard;
+            self.c.wait(&mut owned_guard);
+        }
+        and_then()
+    }
+}
+
+#[derive(Debug)]
+pub struct Coremap<K, V>
 where
     K: Eq + Hash,
 {
-    pub fn new() -> Self {
-        HTable {
-            inner: HashMap::new(),
+    inner: HashTable<K, V>,
+    state_lock: AtomicBool,
+    state_condvar: Cvar,
+}
+
+impl<K: Eq + Hash, V> Deref for HTable<K, V> {
+    type Target = Coremap<K, V>;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// A table lock state guard
+///
+/// This object holds a locked [`Coremap`] object. The locked state corresponds to the internal `state_lock`
+/// `AtomicBool`'s value. You can use the [`TableLockStateGuard`] to reference the actual table and do any operations
+/// on it. It is recommended that whenever you're about to do a BGSAVE operation, call [`Coremap::lock_writes()`]
+/// and you'll get this object. Use this object to mutate/read the data of the inner hashtable and then as soon
+/// as this lock state goes out of scope, you can be sure that all threads waiting to write will get access.
+///
+/// ## Undefined Behavior (UB)
+///
+/// It is **absolutely undefined behavior to hold two lock states** for the same table because each one will
+/// attempt to notify the other waiting threads. This will never happen unless you explicitly attempt to do it
+/// as [`Coremap`] will wait for a [`TableLockStateGuard`] to be available before it gives you one
+pub struct TableLockStateGuard<'a, K, V>
+where
+    K: Eq + Hash + Serialize,
+    V: Serialize,
+{
+    inner: &'a Coremap<K, V>,
+}
+
+impl<'a, K: Eq + Hash + Serialize, V: Serialize> Deref for TableLockStateGuard<'a, K, V> {
+    type Target = Coremap<K, V>;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'a, K: Hash + Eq + Serialize, V: Serialize> Drop for TableLockStateGuard<'a, K, V> {
+    fn drop(&mut self) {
+        unsafe {
+            self.inner._force_unlock_writes();
         }
     }
+}
+
+impl<K, V> Coremap<K, V>
+where
+    K: Eq + Hash + Serialize,
+    V: Serialize,
+{
+    pub fn new() -> Self {
+        Coremap {
+            inner: DashMap::new(),
+            state_lock: AtomicBool::new(false),
+            state_condvar: Cvar::new(),
+        }
+    }
+    /// Returns the total number of key value pairs
     pub fn len(&self) -> usize {
         self.inner.len()
     }
-    pub fn remove<Q>(&mut self, key: &Q) -> Option<(K, V)>
+    /// Returns the removed value for key, it it existed
+    pub fn remove<Q>(&self, key: &Q) -> Option<(K, V)>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        self.inner.remove_entry(key)
+        self.wait_for_write_unlock();
+        self.inner.remove(key)
     }
+    /// Returns true if an existent key was removed
+    pub fn true_if_removed<Q>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.wait_for_write_unlock();
+        self.inner.remove(key).is_some()
+    }
+    /// Check if a table contains a key
     pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
         K: Borrow<Q>,
@@ -70,32 +214,102 @@ where
     {
         self.inner.contains_key(key)
     }
-    pub fn clear(&mut self) {
+    /// Clears the inner table!
+    pub fn clear(&self) {
+        self.wait_for_write_unlock();
         self.inner.clear()
     }
-    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    /// Return a non-consuming iterator
+    pub fn iter(&self) -> Iter<'_, K, V> {
+        self.inner.iter()
+    }
+    /// Get a reference to the value of a key, if it exists
+    pub fn get<Q>(&self, key: &Q) -> Option<Ref<'_, K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.inner.get(key)
     }
-    pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
-        self.inner.entry(key)
+    /// Returns true if the non-existent key was assigned to a value
+    pub fn true_if_insert(&self, k: K, v: V) -> bool {
+        self.wait_for_write_unlock();
+        if let Entry::Vacant(ve) = self.inner.entry(k) {
+            ve.insert(v);
+            true
+        } else {
+            false
+        }
     }
-    pub fn insert(&mut self, k: K, v: V) -> Option<V> {
-        self.inner.insert(k, v)
+    /// Update or insert
+    pub fn upsert(&self, k: K, v: V) {
+        self.wait_for_write_unlock();
+        let _ = self.inner.insert(k, v);
     }
-    pub fn keys(&self) -> Keys<'_, K, V> {
-        self.inner.keys()
+    /// Returns true if the value was updated
+    pub fn true_if_update(&self, k: K, v: V) -> bool {
+        self.wait_for_write_unlock();
+        if let Entry::Occupied(mut oe) = self.inner.entry(k) {
+            oe.insert(v);
+            true
+        } else {
+            false
+        }
     }
-    pub fn values(&self) -> Values<'_, K, V> {
-        self.inner.values()
+    pub fn serialize(&self) -> TResult<Vec<u8>> {
+        bincode::serialize(&self.inner).map_err(|e| e.into())
+    }
+    unsafe fn _force_lock_writes(&self) -> TableLockStateGuard<'_, K, V> {
+        self.state_lock.store(true, ORDERING_RELAXED);
+        self.state_condvar.notify_all();
+        TableLockStateGuard { inner: &self }
+    }
+    unsafe fn _force_unlock_writes(&self) {
+        self.state_lock.store(false, ORDERING_RELAXED);
+        self.state_condvar.notify_all();
+    }
+    /// Blocks the current thread, waiting for an unlock on writes
+    fn wait_for_write_unlock(&self) {
+        self.state_condvar.wait(&self.state_lock);
+    }
+    fn wait_for_write_unlock_and_then<T, F>(&self, then: F) -> T
+    where
+        F: Fn() -> T,
+    {
+        self.state_condvar
+            .wait_and_then_immediately(&self.state_lock, then)
+    }
+    pub fn lock_writes(&self) -> TableLockStateGuard<'_, K, V> {
+        self.wait_for_write_unlock_and_then(|| unsafe {
+            // since we've got a write unlock at this exact point, we're free to lock the table
+            // so this _should be_ safe
+            // FIXME: UB/race condition here? What if exactly after the write unlock another thread does a lock_writes?
+            self._force_lock_writes()
+        })
     }
 }
-impl<K: Eq + Hash, V> IntoIterator for HTable<K, V> {
+
+impl Coremap<Data, Data> {
+    pub fn deserialize(src: Vec<u8>) -> TResult<Self> {
+        let h: HashTable<Data, Data> = bincode::deserialize(&src)?;
+        Ok(Self {
+            inner: h,
+            state_lock: AtomicBool::new(false),
+            state_condvar: Cvar::new(),
+        })
+    }
+    pub fn get_keys(&self, count: usize) -> Vec<Bytes> {
+        let mut v = Vec::with_capacity(count);
+        self.iter()
+            .take(count)
+            .map(|kv| kv.key().get_blob().clone())
+            .for_each(|key| v.push(key));
+        v
+    }
+}
+impl<K: Eq + Hash, V> IntoIterator for Coremap<K, V> {
     type Item = (K, V);
-    type IntoIter = std::collections::hash_map::IntoIter<K, V>;
+    type IntoIter = dashmap::iter::OwningIter<K, V>;
     fn into_iter(self) -> Self::IntoIter {
         self.inner.into_iter()
     }
@@ -128,8 +342,30 @@ where
     where
         T: IntoIterator<Item = (K, V)>,
     {
-        HTable {
-            inner: HashMap::from_iter(iter),
+        Self {
+            inner: Arc::new(Coremap {
+                inner: DashMap::from_iter(iter),
+                state_lock: AtomicBool::new(false),
+                state_condvar: Cvar::new(),
+            }),
+            _marker_value: PhantomData,
+            _marker_key: PhantomData,
+        }
+    }
+}
+
+impl<K, V> FromIterator<(K, V)> for Coremap<K, V>
+where
+    K: Eq + Hash,
+{
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = (K, V)>,
+    {
+        Coremap {
+            inner: DashMap::from_iter(iter),
+            state_lock: AtomicBool::new(false),
+            state_condvar: Cvar::new(),
         }
     }
 }
@@ -154,10 +390,6 @@ impl Data {
     }
     /// Get the inner blob (raw `Bytes`)
     pub const fn get_blob(&self) -> &Bytes {
-        &self.blob
-    }
-    /// Get the inner blob as an `u8` slice (coerced)
-    pub fn get_inner_ref(&self) -> &[u8] {
         &self.blob
     }
 }
@@ -229,15 +461,16 @@ impl<'de> Deserialize<'de> for Data {
 
 #[test]
 fn test_de() {
-    let mut x: HTable<String, Data> = HTable::new();
-    x.insert(
-        String::from("Sayan"),
+    let x = HTable::new();
+    x.upsert(
+        Data::from("sayan"),
         Data::from_string("is writing open-source code".to_owned()),
     );
-    let ser = bincode::serialize(&x).unwrap();
-    let de: HTable<String, Data> = bincode::deserialize(&ser).unwrap();
-    assert_eq!(de, x);
-    let mut hmap: HTable<Data, Data> = HTable::new();
-    hmap.insert(Data::from("sayan"), Data::from("writes code"));
+    let ser = x.serialize().unwrap();
+    let de = Coremap::deserialize(ser).unwrap();
+    assert!(de.contains_key(&Data::from("sayan")));
+    assert!(de.len() == x.len());
+    let hmap: Coremap<Data, Data> = Coremap::new();
+    hmap.upsert(Data::from("sayan"), Data::from("writes code"));
     assert!(hmap.get("sayan".as_bytes()).is_some());
 }

--- a/server/src/coredb/mod.rs
+++ b/server/src/coredb/mod.rs
@@ -46,6 +46,7 @@ pub mod htable;
 pub struct CoreDB {
     /// The shared object, which contains a `Shared` object wrapped in an atomic RC
     pub shared: Arc<Shared>,
+    /// The actual in-memory hashtable
     pub coremap: HTable<Data, Data>,
 }
 
@@ -193,6 +194,7 @@ impl CoreDB {
     pub fn is_poisoned(&self) -> bool {
         *(self.shared).poisoned.read()
     }
+    /// Provides a reference to the shared [`Coremap`] object
     pub fn get_ref(&self) -> &HTable<Data, Data> {
         &self.coremap
     }

--- a/server/src/dbnet/connection.rs
+++ b/server/src/dbnet/connection.rs
@@ -26,14 +26,14 @@
 
 //! # Generic connection traits
 //! The `con` module defines the generic connection traits `ProtocolConnection` and `ProtocolConnectionExt`.
-//! These two traits can be used to interface with sockets that are used for communication through the Terrapipe
+//! These two traits can be used to interface with sockets that are used for communication through the Skyhash
 //! protocol.
 //!
 //! The `ProtocolConnection` trait provides a basic set of methods that are required by prospective connection
 //! objects to be eligible for higher level protocol interactions (such as interactions with high-level query objects).
 //! Once a type implements this trait, it automatically gets a free `ProtocolConnectionExt` implementation. This immediately
 //! enables this connection object/type to use methods like read_query enabling it to read and interact with queries and write
-//! respones in compliance with the Terrapipe protocol.
+//! respones in compliance with the Skyhash protocol.
 
 use super::tcp::Connection;
 use crate::dbnet::tcp::BufferedSocketStream;

--- a/server/src/kvengine/dbsize.rs
+++ b/server/src/kvengine/dbsize.rs
@@ -39,7 +39,7 @@ where
     crate::err_if_len_is!(act, con, != 0);
     let len;
     {
-        len = handle.acquire_read().get_ref().len();
+        len = handle.get_ref().len();
     }
     con.write_response(len).await?;
     Ok(())

--- a/server/src/kvengine/del.rs
+++ b/server/src/kvengine/del.rs
@@ -46,19 +46,18 @@ where
     crate::err_if_len_is!(act, con, == 0);
     let done_howmany: Option<usize>;
     {
-        if let Some(mut whandle) = handle.acquire_write() {
+        if handle.is_poisoned() {
+            done_howmany = None;
+        } else {
             let mut many = 0;
-            let cmap = (*whandle).get_mut_ref();
+            let cmap = handle.get_ref();
             act.into_iter().skip(1).for_each(|key| {
-                if cmap.remove(key.as_bytes()).is_some() {
+                if cmap.true_if_removed(key.as_bytes()) {
                     many += 1
                 }
             });
             drop(cmap);
-            drop(whandle);
             done_howmany = Some(many);
-        } else {
-            done_howmany = None;
         }
     }
     if let Some(done_howmany) = done_howmany {

--- a/server/src/kvengine/exists.rs
+++ b/server/src/kvengine/exists.rs
@@ -42,15 +42,13 @@ where
     crate::err_if_len_is!(act, con, == 0);
     let mut how_many_of_them_exist = 0usize;
     {
-        let rhandle = handle.acquire_read();
-        let cmap = rhandle.get_ref();
+        let cmap = handle.get_ref();
         act.into_iter().skip(1).for_each(|key| {
             if cmap.contains_key(key.as_bytes()) {
                 how_many_of_them_exist += 1;
             }
         });
         drop(cmap);
-        drop(rhandle);
     }
     con.write_response(how_many_of_them_exist).await?;
     Ok(())

--- a/server/src/kvengine/flushdb.rs
+++ b/server/src/kvengine/flushdb.rs
@@ -40,11 +40,11 @@ where
     crate::err_if_len_is!(act, con, != 0);
     let failed;
     {
-        if let Some(mut table) = handle.acquire_write() {
-            table.get_mut_ref().clear();
-            failed = false;
-        } else {
+        if handle.is_poisoned() {
             failed = true;
+        } else {
+            handle.get_ref().clear();
+            failed = false;
         }
     }
     if failed {

--- a/server/src/kvengine/get.rs
+++ b/server/src/kvengine/get.rs
@@ -44,8 +44,7 @@ where
 {
     crate::err_if_len_is!(act, con, != 1);
     let res: Option<Bytes> = {
-        let rhandle = handle.acquire_read();
-        let reader = rhandle.get_ref();
+        let reader = handle.get_ref();
         unsafe {
             // UNSAFE(@ohsayan): act.get_ref().get_unchecked() is safe because we've already if the action
             // group contains one argument (excluding the action itself)

--- a/server/src/kvengine/keylen.rs
+++ b/server/src/kvengine/keylen.rs
@@ -41,8 +41,7 @@ where
 {
     crate::err_if_len_is!(act, con, != 1);
     let res: Option<usize> = {
-        let rhandle = handle.acquire_read();
-        let reader = rhandle.get_ref();
+        let reader = handle.get_ref();
         unsafe {
             // UNSAFE(@ohsayan): get_unchecked() is completely safe as we've already checked
             // the number of arguments is one

--- a/server/src/kvengine/lskeys.rs
+++ b/server/src/kvengine/lskeys.rs
@@ -53,13 +53,8 @@ where
     };
     let items: Vec<Bytes>;
     {
-        let rhandle = handle.acquire_read();
-        let reader = rhandle.get_ref();
-        items = reader
-            .keys()
-            .map(|key| key.get_blob().clone())
-            .take(item_count)
-            .collect();
+        let reader = handle.get_ref();
+        items = reader.get_keys(item_count);
     }
     con.write_flat_array_length(items.len()).await?;
     for item in items {

--- a/server/src/kvengine/mget.rs
+++ b/server/src/kvengine/mget.rs
@@ -45,8 +45,7 @@ where
     let mut keys = act.into_iter().skip(1);
     while let Some(key) = keys.next() {
         let res: Option<Bytes> = {
-            let rhandle = handle.acquire_read();
-            let reader = rhandle.get_ref();
+            let reader = handle.get_ref();
             reader.get(key.as_bytes()).map(|b| b.get_blob().clone())
         };
         if let Some(value) = res {

--- a/server/src/kvengine/mset.rs
+++ b/server/src/kvengine/mset.rs
@@ -24,8 +24,6 @@
  *
 */
 
-use crate::coredb;
-use crate::coredb::htable::Entry;
 use crate::coredb::Data;
 use crate::dbnet::connection::prelude::*;
 use crate::protocol::responses;
@@ -50,20 +48,18 @@ where
     let mut kviter = act.into_iter().skip(1);
     let done_howmany: Option<usize>;
     {
-        if let Some(mut whandle) = handle.acquire_write() {
-            let writer = whandle.get_mut_ref();
+        if handle.is_poisoned() {
+            done_howmany = None;
+        } else {
+            let writer = handle.get_ref();
             let mut didmany = 0;
             while let (Some(key), Some(val)) = (kviter.next(), kviter.next()) {
-                if let Entry::Vacant(v) = writer.entry(Data::from(key)) {
-                    let _ = v.insert(coredb::Data::from_string(val));
+                if writer.true_if_insert(Data::from(key), Data::from(val)) {
                     didmany += 1;
                 }
             }
             drop(writer);
-            drop(whandle);
             done_howmany = Some(didmany);
-        } else {
-            done_howmany = None;
         }
     }
     if let Some(done_howmany) = done_howmany {

--- a/server/src/kvengine/uset.rs
+++ b/server/src/kvengine/uset.rs
@@ -49,16 +49,15 @@ where
     }
     let mut kviter = act.into_iter().skip(1);
     let failed = {
-        if let Some(mut whandle) = handle.acquire_write() {
-            let writer = whandle.get_mut_ref();
+        if handle.is_poisoned() {
+            true
+        } else {
+            let writer = handle.get_ref();
             while let (Some(key), Some(val)) = (kviter.next(), kviter.next()) {
-                let _ = writer.insert(Data::from(key), Data::from(val));
+                let _ = writer.upsert(Data::from(key), Data::from(val));
             }
             drop(writer);
-            drop(whandle);
             false
-        } else {
-            true
         }
     };
     if failed {

--- a/server/src/protocol/responses.rs
+++ b/server/src/protocol/responses.rs
@@ -24,7 +24,7 @@
  *
 */
 
-//! Primitives for generating Terrapipe compatible responses
+//! Primitives for generating Skyhash compatible responses
 
 pub mod groups {
     //! # Pre-compiled response **elements**

--- a/server/src/services/bgsave.rs
+++ b/server/src/services/bgsave.rs
@@ -90,8 +90,8 @@ pub fn _bgsave_blocking_section(handle: &CoreDB) -> TResult<()> {
     // first lock our temporary file
     let mut file = flock::FileLock::lock(SKY_TEMP_FILE)?;
     // get a read lock on the coretable
-    let lock = handle.acquire_read();
-    diskstore::flush_data(&mut file, lock.get_ref())?;
+    let lock = handle.lock_writes();
+    diskstore::flush_data(&mut file, &*lock)?;
     // now rename the file
     #[cfg(not(test))]
     fs::rename(SKY_TEMP_FILE, &*PERSIST_FILE)?;


### PR DESCRIPTION
`Coremap` abstracts a lot of the internal details away that would otherwise make working with actions very hard. It also makes _freezing_ or locking a table during a save task more reliable. A few notable changes:
- Switched hashtable implementation
- Methods like `supdate` and `sset` will block if the background task kicks in
- Background save methods have the ability to freeze the table through `Coremap`'s `lock_writes` member function and unfreeze the table by dropping `TableLockStateGuard` (or letting it go out of scope)
