### PR TITLE
Enable maximum connections to be configured manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All changes in this project will be noted in this file.
 
+## Unreleased
+
+### Additions
+
+- The maximum number of clients can now be manually configured [see [#182](https://github.com/skytable/skytable/pull/182)]
+
+### Fixes
+
+- Ability to connect to the server over TLS has been restored in `skysh` [see [#181](https://github.com/skytable/skytable/pull/181)]
+
 ## Version 0.6.2 [2021-06-24]
 
 ### Fixes

--- a/examples/config-files/template.toml
+++ b/examples/config-files/template.toml
@@ -11,6 +11,7 @@ host = "127.0.0.1" # The IP address to which you want sdb to bind to
 port = 2003 # The port to which you want sdb to bind to
 # Set `noart` to true if you want to disable terminal artwork
 noart = false
+maxcon = 50000 # set the maximum number of clients that the server can accept
 
 # This key is *OPTIONAL*
 [bgsave]

--- a/server/src/arbiter.rs
+++ b/server/src/arbiter.rs
@@ -1,0 +1,131 @@
+/*
+ * Created on Sat Jun 26 2021
+ *
+ * This file is a part of Skytable
+ * Skytable (formerly known as TerrabaseDB or Skybase) is a free and open-source
+ * NoSQL database written by Sayan Nandan ("the Author") with the
+ * vision to provide flexibility in data modelling without compromising
+ * on performance, queryability or scalability.
+ *
+ * Copyright (c) 2021, Sayan Nandan <ohsayan@outlook.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+*/
+
+use crate::config::BGSave;
+use crate::config::SnapshotConfig;
+use crate::coredb::CoreDB;
+use crate::dbnet::{self, Terminator};
+use crate::diskstore::snapshot::DIR_REMOTE_SNAPSHOT;
+use crate::services;
+use crate::PortConfig;
+use std::fs;
+use tokio::sync::broadcast;
+
+#[cfg(unix)]
+use core::{future::Future, pin::Pin, task::Context, task::Poll};
+#[cfg(unix)]
+use tokio::signal::unix::{signal as fnsignal, Signal, SignalKind};
+#[cfg(unix)]
+/// Object to bind to unix-specific signals
+pub struct UnixTerminationSignal {
+    sigterm: Signal,
+}
+
+#[cfg(unix)]
+impl UnixTerminationSignal {
+    pub fn init() -> Result<Self, String> {
+        let sigterm = fnsignal(SignalKind::terminate())
+            .map_err(|e| format!("Failed to bind to signal with: {}", e))?;
+        Ok(Self { sigterm })
+    }
+}
+
+#[cfg(unix)]
+impl Future for UnixTerminationSignal {
+    type Output = Option<()>;
+
+    fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.sigterm.poll_recv(ctx)
+    }
+}
+
+/// Start the server waiting for incoming connections or a termsig
+pub async fn run(
+    ports: PortConfig,
+    bgsave_cfg: BGSave,
+    snapshot_cfg: SnapshotConfig,
+    restore_filepath: Option<String>,
+    maxcon: usize,
+) -> Result<CoreDB, String> {
+    // Intialize the broadcast channel
+    let (signal, _) = broadcast::channel(1);
+
+    // create the data directories and intialize the coredb
+    fs::create_dir_all(&*DIR_REMOTE_SNAPSHOT)
+        .map_err(|e| format!("Failed to create data directories: '{}'", e))?;
+    let db = CoreDB::new(&snapshot_cfg, restore_filepath)
+        .map_err(|e| format!("Error while initializing database: {}", e))?;
+
+    // initialize the background services
+    let bgsave_handle = tokio::spawn(services::bgsave::bgsave_scheduler(
+        db.clone(),
+        bgsave_cfg,
+        Terminator::new(signal.subscribe()),
+    ));
+    let snapshot_handle = tokio::spawn(services::snapshot::snapshot_service(
+        db.clone(),
+        snapshot_cfg,
+        Terminator::new(signal.subscribe()),
+    ));
+
+    // bind the ctrlc handler
+    let sig = tokio::signal::ctrl_c();
+
+    // start the server (single or multiple listeners)
+    let mut server = dbnet::connect(ports, maxcon, db.clone(), signal.clone()).await?;
+
+    #[cfg(not(unix))]
+    {
+        // Non-unix, usually Windows specific signal handling.
+        // FIXME(@ohsayan): For now, let's just
+        // bother with ctrl+c, we'll move ahead as users require them
+        tokio::select! {
+            _ = server.run_server() => {}
+            _ = sig => {}
+        }
+    }
+    #[cfg(unix)]
+    {
+        let sigterm = UnixTerminationSignal::init()?;
+        // apart from CTRLC, the only other thing we care about is SIGTERM
+        // FIXME(@ohsayan): Maybe we should respond to SIGHUP too?
+        tokio::select! {
+            _ = server.run_server() => {},
+            _ = sig => {},
+            _ = sigterm => {}
+        }
+    }
+
+    log::info!("Signalling all workers to shut down");
+    // drop the signal and let others exit
+    drop(signal);
+    server.finish_with_termsig().await;
+
+    // wait for the background services to terminate
+    let _ = snapshot_handle.await;
+    let _ = bgsave_handle.await;
+    Ok(db)
+}

--- a/server/src/cli.yml
+++ b/server/src/cli.yml
@@ -84,6 +84,12 @@ args:
       long: stop-write-on-fail
       takes_value: true
       help: Stop accepting writes if any persistence method except BGSAVE fails (defaults to true)
+  - maxcon:
+      required: false
+      long: maxcon
+      takes_value: true
+      help: Set the maximum number of connections
+      value_name: maxcon
 subcommands:
   - upgrade:
       about: Upgrades old datsets to the latest format supported by this server edition

--- a/server/src/config/mod.rs
+++ b/server/src/config/mod.rs
@@ -461,6 +461,7 @@ pub fn get_config_file_or_return_cfg() -> Result<ConfigType<ParsedConfig, String
         || saveduration.is_some()
         || sslchain.is_some()
         || sslkey.is_some()
+        || maxcon.is_some()
         || sslonly;
     if filename.is_some() && cli_has_overrideable_args {
         return Err(ConfigError::CfgError(

--- a/server/src/dbnet/mod.rs
+++ b/server/src/dbnet/mod.rs
@@ -39,19 +39,11 @@
 //! 5. Now errors are handled if they occur. Otherwise, the query is executed by `CoreDB::execute_query()`
 //!
 
-use crate::config::BGSave;
+use self::tcp::Listener;
 use crate::config::PortConfig;
-use crate::config::SnapshotConfig;
 use crate::config::SslOpts;
-use crate::dbnet::tcp::Listener;
-use crate::diskstore;
-use crate::services;
-use diskstore::snapshot::DIR_REMOTE_SNAPSHOT;
-mod tcp;
 use crate::coredb::CoreDB;
 use libsky::TResult;
-use std::fs;
-use std::future::Future;
 use std::io::Error as IoError;
 use std::net::IpAddr;
 use std::sync::Arc;
@@ -60,6 +52,7 @@ use tokio::net::TcpListener;
 use tokio::sync::Semaphore;
 use tokio::sync::{broadcast, mpsc};
 pub mod connection;
+mod tcp;
 mod tls;
 
 pub const MAXIMUM_CONNECTION_LIMIT: usize = 50000;
@@ -165,7 +158,7 @@ macro_rules! bindaddr {
 /// - The `Multi` variant holds both an `SslListener` and a `Listener`
 ///     This variant enables listening to both secure and insecure sockets at the same time
 ///     asynchronously
-enum MultiListener {
+pub enum MultiListener {
     SecureOnly(SslListener),
     InsecureOnly(Listener),
     Multi(Listener, SslListener),
@@ -246,60 +239,15 @@ impl MultiListener {
     }
 }
 
-#[cfg(unix)]
-use core::{pin::Pin, task::Context, task::Poll};
-#[cfg(unix)]
-use tokio::signal::unix::{signal as fnsignal, Signal, SignalKind};
-#[cfg(unix)]
-/// Object to bind to unix-specific signals
-pub struct UnixTerminationSignal {
-    sigterm: Signal,
-}
-
-#[cfg(unix)]
-impl UnixTerminationSignal {
-    pub fn init() -> Result<Self, String> {
-        let sigterm = fnsignal(SignalKind::terminate())
-            .map_err(|e| format!("Failed to bind to signal with: {}", e))?;
-        Ok(Self { sigterm })
-    }
-}
-
-#[cfg(unix)]
-impl Future for UnixTerminationSignal {
-    type Output = Option<()>;
-
-    fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.sigterm.poll_recv(ctx)
-    }
-}
-
-/// Start the server waiting for incoming connections or a CTRL+C signal
-pub async fn run(
+/// Initialize the database networking
+pub async fn connect(
     ports: PortConfig,
-    bgsave_cfg: BGSave,
-    snapshot_cfg: SnapshotConfig,
-    sig: impl Future,
-    restore_filepath: Option<String>,
     maxcon: usize,
-) -> Result<CoreDB, String> {
+    db: CoreDB,
+    signal: broadcast::Sender<()>,
+) -> Result<MultiListener, String> {
     let climit = Arc::new(Semaphore::const_new(maxcon));
-    let (signal, _) = broadcast::channel(1);
-    fs::create_dir_all(&*DIR_REMOTE_SNAPSHOT)
-        .map_err(|e| format!("Failed to create data directories: '{}'", e))?;
-    let db = CoreDB::new(&snapshot_cfg, restore_filepath)
-        .map_err(|e| format!("Error while initializing database: {}", e))?;
-    let bgsave_handle = tokio::spawn(services::bgsave::bgsave_scheduler(
-        db.clone(),
-        bgsave_cfg,
-        Terminator::new(signal.subscribe()),
-    ));
-    let snapshot_handle = tokio::spawn(services::snapshot::snapshot_service(
-        db.clone(),
-        snapshot_cfg,
-        Terminator::new(signal.subscribe()),
-    ));
-    let mut server = match ports {
+    let server = match ports {
         PortConfig::InsecureOnly { host, port } => MultiListener::new_insecure_only(
             BaseListener::init(&db, host, port, climit.clone(), signal.clone())
                 .await
@@ -323,32 +271,5 @@ pub async fn run(
             MultiListener::new_multi(secure_listener, insecure_listener, ssl).await?
         }
     };
-    #[cfg(not(unix))]
-    {
-        // Non-unix, usually Windows specific signal handling.
-        // FIXME(@ohsayan): For now, let's just
-        // bother with ctrl+c, we'll move ahead as users require them
-        tokio::select! {
-            _ = server.run_server() => {}
-            _ = sig => {}
-        }
-    }
-    #[cfg(unix)]
-    {
-        let sigterm = UnixTerminationSignal::init()?;
-        // apart from CTRLC, the only other thing we care about is SIGTERM
-        // FIXME(@ohsayan): Maybe we should respond to SIGHUP too?
-        tokio::select! {
-            _ = server.run_server() => {},
-            _ = sig => {},
-            _ = sigterm => {}
-        }
-    }
-    log::info!("Signalling all workers to shut down");
-    // drop the signal and let others exit
-    drop(signal);
-    server.finish_with_termsig().await;
-    let _ = snapshot_handle.await;
-    let _ = bgsave_handle.await;
-    Ok(db)
+    Ok(server)
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -45,9 +45,9 @@ use std::process;
 use std::sync::Arc;
 use std::thread;
 use std::time;
-use tokio::signal;
 mod actions;
 mod admin;
+mod arbiter;
 mod compat;
 mod config;
 mod coredb;
@@ -92,16 +92,14 @@ fn main() {
     // involve passing --help or wrong arguments which can falsely create a PID file
     let pid_file = run_pre_startup_tasks();
     let db: Result<coredb::CoreDB, String> = runtime.block_on(async move {
-        let db = dbnet::run(
+        arbiter::run(
             ports,
             bgsave_config,
             snapshot_config,
-            signal::ctrl_c(),
             restore_filepath,
             maxcon,
         )
-        .await;
-        db
+        .await
     });
     // Make sure all background workers terminate
     drop(runtime);


### PR DESCRIPTION
This PR enables the maximum number of connections to be set to an user defined limit. If no limit is provided, it defaults to a value of 50000. This is quite an important consideration and _can aid_ in controlling several kinds of attacks which would otherwise cause a system with low resources to crash.