### PR TITLE
Enable TLS port to be configured via CLI args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All changes in this project will be noted in this file.
 
+## Unreleased
+
+### Fixes
+
+- Zero length argument causing runtime panic in `skysh`
+
+### Additions
+
+- TLS port can now be set to a custom port via CLI arguments
+
 ## Version 0.6.3 [2021-06-27]
 
 ### Additions

--- a/server/src/cli.yml
+++ b/server/src/cli.yml
@@ -79,6 +79,12 @@ args:
       long: sslonly
       takes_value: false
       help: Tells the server to only accept SSL connections and disables the non-SSL port
+  - sslport:
+      required: false
+      long: sslport
+      takes_value: true
+      value_name: sslport
+      help: Set a custom SSL port to bind to
   - stopwriteonfail:
       required: false
       long: stop-write-on-fail


### PR DESCRIPTION
I don't know how we possibly didn't include this in the first place, but here it is :)