### PR TITLE
Remove trailing semicolons from macros

### DIFF
--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -61,19 +61,19 @@ impl AsyncSocket for aio::TlsConnection {
 
 macro_rules! write_string {
     ($st:ident) => {
-        println!("\"{}\"", $st);
+        println!("\"{}\"", $st)
     };
     ($idx:ident, $st:ident) => {
-        println!("({}) \"{}\"", $idx, $st);
+        println!("({}) \"{}\"", $idx, $st)
     };
 }
 
 macro_rules! write_int {
     ($int:ident) => {
-        println!("{}", $int);
+        println!("{}", $int)
     };
     ($idx:ident, $st:ident) => {
-        println!("({}) \"{}\"", $idx, $st);
+        println!("({}) \"{}\"", $idx, $st)
     };
 }
 
@@ -89,7 +89,7 @@ macro_rules! write_err {
             }),
             ResetColor
         )
-        .expect("Failed to write to stdout");
+        .expect("Failed to write to stdout")
     };
     ($idx:ident, $err:literal) => {
         crossterm::execute!(
@@ -104,7 +104,7 @@ macro_rules! write_err {
             ),
             ResetColor
         )
-        .expect("Failed to write to stdout");
+        .expect("Failed to write to stdout")
     };
 }
 
@@ -116,7 +116,7 @@ macro_rules! write_okay {
             Print("(Okay)\n".to_string()),
             ResetColor
         )
-        .expect("Failed to write to stdout");
+        .expect("Failed to write to stdout")
     };
     ($idx:ident) => {
         crossterm::execute!(
@@ -125,7 +125,7 @@ macro_rules! write_okay {
             Print(format!("({}) (Okay)\n", $idx)),
             ResetColor
         )
-        .expect("Failed to write to stdout");
+        .expect("Failed to write to stdout")
     };
 }
 

--- a/server/src/corestore/buffers.rs
+++ b/server/src/corestore/buffers.rs
@@ -30,7 +30,7 @@ use core::str;
 
 macro_rules! push_self {
     ($self:expr, $what:expr) => {
-        $self.inner_stack.push_unchecked($what);
+        $self.inner_stack.push_unchecked($what)
     };
 }
 

--- a/server/src/dbnet/connection.rs
+++ b/server/src/dbnet/connection.rs
@@ -135,7 +135,7 @@ pub mod prelude {
     #[macro_export]
     macro_rules! aerr {
         ($con:expr, aerr) => {
-            return conwrite!($con, crate::protocol::responses::groups::ACTION_ERR);
+            return conwrite!($con, crate::protocol::responses::groups::ACTION_ERR)
         };
     }
     #[macro_export]

--- a/server/src/dbnet/mod.rs
+++ b/server/src/dbnet/mod.rs
@@ -146,7 +146,7 @@ macro_rules! bindaddr {
         $base
             .listener
             .local_addr()
-            .map_err(|e| format!("Failed to get bind address: {}", e))?;
+            .map_err(|e| format!("Failed to get bind address: {}", e))?
     };
 }
 


### PR DESCRIPTION
This fixes warnings on the latest nightly.
See https://github.com/rust-lang/rust/issues/79813