### PR TITLE
Optimize the Skyhash implementation

### DIFF
--- a/server/src/actions/dbsize.rs
+++ b/server/src/actions/dbsize.rs
@@ -28,7 +28,7 @@ use crate::dbnet::connection::prelude::*;
 
 action!(
     /// Returns the number of keys in the database
-    fn dbsize(handle: &Corestore, con: &mut T, mut act: ActionIter) {
+    fn dbsize(handle: &Corestore, con: &'a mut T, mut act: ActionIter<'a>) {
         err_if_len_is!(act, con, gt 1);
         if act.len() == 0 {
             let len;

--- a/server/src/actions/del.rs
+++ b/server/src/actions/del.rs
@@ -35,14 +35,14 @@ action!(
     ///
     /// Do note that this function is blocking since it acquires a write lock.
     /// It will write an entire datagroup, for this `del` action
-    fn del(handle: &Corestore, con: &mut T, act: ActionIter) {
+    fn del(handle: &Corestore, con: &'a mut T, act: ActionIter<'a>) {
         err_if_len_is!(act, con, eq 0);
         let kve = kve!(con, handle);
         let encoding_is_okay = if kve.needs_key_encoding() {
             true
         } else {
             let encoder = kve.get_key_encoder();
-            act.as_ref().iter().all(|k| encoder.is_ok(k))
+            act.as_ref().all(|k| encoder.is_ok(k))
         };
         if compiler::likely(encoding_is_okay) {
             let done_howmany: Option<usize>;
@@ -50,7 +50,7 @@ action!(
                 if registry::state_okay() {
                     let mut many = 0;
                     act.for_each(|key| {
-                        if kve.remove_unchecked(&key) {
+                        if kve.remove_unchecked(key) {
                             many += 1
                         }
                     });

--- a/server/src/actions/exists.rs
+++ b/server/src/actions/exists.rs
@@ -33,7 +33,7 @@ use crate::util::compiler;
 
 action!(
     /// Run an `EXISTS` query
-    fn exists(handle: &Corestore, con: &mut T, act: ActionIter) {
+    fn exists(handle: &Corestore, con: &'a mut T, act: ActionIter<'a>) {
         err_if_len_is!(act, con, eq 0);
         let mut how_many_of_them_exist = 0usize;
         let kve = kve!(con, handle);
@@ -41,12 +41,12 @@ action!(
             true
         } else {
             let encoder = kve.get_key_encoder();
-            act.as_ref().iter().all(|k| encoder.is_ok(k))
+            act.as_ref().all(|k| encoder.is_ok(k))
         };
         if compiler::likely(encoding_is_okay) {
             {
                 act.for_each(|key| {
-                    if kve.exists_unchecked(&key) {
+                    if kve.exists_unchecked(key) {
                         how_many_of_them_exist += 1;
                     }
                 });

--- a/server/src/actions/flushdb.rs
+++ b/server/src/actions/flushdb.rs
@@ -37,7 +37,7 @@ action!(
                 get_tbl!(handle, con).truncate_table();
             } else {
                 // flush the entity
-                let raw_entity = unsafe { act.next().unsafe_unwrap() };
+                let raw_entity = unsafe { act.next_unchecked() };
                 let entity = handle_entity!(con, raw_entity);
                 get_tbl!(entity, handle, con).truncate_table();
             }

--- a/server/src/actions/flushdb.rs
+++ b/server/src/actions/flushdb.rs
@@ -29,7 +29,7 @@ use crate::queryengine::ActionIter;
 
 action!(
     /// Delete all the keys in the database
-    fn flushdb(handle: &Corestore, con: &mut T, mut act: ActionIter) {
+    fn flushdb(handle: &Corestore, con: &'a mut T, mut act: ActionIter<'a>) {
         err_if_len_is!(act, con, gt 1);
         if registry::state_okay() {
             if act.len() == 0 {

--- a/server/src/actions/get.rs
+++ b/server/src/actions/get.rs
@@ -33,11 +33,11 @@ use crate::util::compiler;
 
 action!(
     /// Run a `GET` query
-    fn get(handle: &crate::corestore::Corestore, con: &mut T, mut act: ActionIter) {
+    fn get(handle: &crate::corestore::Corestore, con: &mut T, mut act: ActionIter<'a>) {
         err_if_len_is!(act, con, not 1);
         let kve = kve!(con, handle);
         unsafe {
-            match kve.get_cloned_with_tsymbol(&act.next().unsafe_unwrap()) {
+            match kve.get_cloned_with_tsymbol(act.next_unchecked()) {
                 Ok((Some(val), tsymbol)) => writer::write_raw_mono(con, tsymbol, &val).await?,
                 Err(_) => compiler::cold_err(conwrite!(con, groups::ENCODING_ERROR))?,
                 Ok(_) => conwrite!(con, groups::NIL)?,

--- a/server/src/actions/jget.rs
+++ b/server/src/actions/jget.rs
@@ -40,7 +40,7 @@ action! {
     /// {"key":"value"}\n
     /// ```
     ///
-    fn jget(_handle: &crate::corestore::Corestore, con: &mut T, act: ActionIter) {
+    fn jget(_handle: &crate::corestore::Corestore, con: &mut T, act: ActionIter<'a>) {
         err_if_len_is!(act, con, not 1);
         todo!()
     }

--- a/server/src/actions/keylen.rs
+++ b/server/src/actions/keylen.rs
@@ -30,14 +30,14 @@ action!(
     /// Run a `KEYLEN` query
     ///
     /// At this moment, `keylen` only supports a single key
-    fn keylen(handle: &crate::corestore::Corestore, con: &mut T, mut act: ActionIter) {
+    fn keylen(handle: &crate::corestore::Corestore, con: &mut T, mut act: ActionIter<'a>) {
         err_if_len_is!(act, con, not 1);
         let res: Option<usize> = {
             let reader = kve!(con, handle);
             unsafe {
                 // UNSAFE(@ohsayan): this is completely safe as we've already checked
                 // the number of arguments is one
-                match reader.get(&act.next().unsafe_unwrap()) {
+                match reader.get(act.next_unchecked()) {
                     Ok(v) => v.map(|b| b.len()),
                     Err(_) => None,
                 }

--- a/server/src/actions/lskeys.rs
+++ b/server/src/actions/lskeys.rs
@@ -39,7 +39,7 @@ action!(
             (get_tbl!(handle, con), DEFAULT_COUNT)
         } else if act.len() == 1 {
             // two args, could either be count or an entity
-            let nextret = unsafe { act.next().unsafe_unwrap() };
+            let nextret = unsafe { act.next_unchecked() };
             if unsafe { nextret.get_unchecked(0) }.is_ascii_digit() {
                 // noice, this is a number; let's try to parse it
                 let count = if let Ok(cnt) = String::from_utf8_lossy(nextret).parse::<usize>() {

--- a/server/src/actions/lskeys.rs
+++ b/server/src/actions/lskeys.rs
@@ -33,7 +33,7 @@ const DEFAULT_COUNT: usize = 10;
 
 action!(
     /// Run an `LSKEYS` query
-    fn lskeys(handle: &crate::corestore::Corestore, con: &mut T, mut act: ActionIter) {
+    fn lskeys(handle: &crate::corestore::Corestore, con: &mut T, mut act: ActionIter<'a>) {
         err_if_len_is!(act, con, gt 3);
         let (table, count) = if act.len() == 0 {
             (get_tbl!(handle, con), DEFAULT_COUNT)
@@ -42,7 +42,7 @@ action!(
             let nextret = unsafe { act.next().unsafe_unwrap() };
             if unsafe { nextret.get_unchecked(0) }.is_ascii_digit() {
                 // noice, this is a number; let's try to parse it
-                let count = if let Ok(cnt) = String::from_utf8_lossy(&nextret).parse::<usize>() {
+                let count = if let Ok(cnt) = String::from_utf8_lossy(nextret).parse::<usize>() {
                     cnt
                 } else {
                     return con.write_response(responses::groups::WRONGTYPE_ERR).await;
@@ -58,7 +58,7 @@ action!(
             let entity_ret = unsafe { act.next().unsafe_unwrap() };
             let count_ret = unsafe { act.next().unsafe_unwrap() };
             let entity = handle_entity!(con, entity_ret);
-            let count = if let Ok(cnt) = String::from_utf8_lossy(&count_ret).parse::<usize>() {
+            let count = if let Ok(cnt) = String::from_utf8_lossy(count_ret).parse::<usize>() {
                 cnt
             } else {
                 return con.write_response(responses::groups::WRONGTYPE_ERR).await;

--- a/server/src/actions/mod.rs
+++ b/server/src/actions/mod.rs
@@ -53,10 +53,10 @@ pub mod heya {
     use crate::resp::BytesWrapper;
     action!(
         /// Returns a `HEY!` `Response`
-        fn heya(_handle: &Corestore, con: &mut T, mut act: ActionIter) {
+        fn heya(_handle: &Corestore, con: &'a mut T, mut act: ActionIter<'a>) {
             err_if_len_is!(act, con, gt 1);
             if act.len() == 1 {
-                let raw_byte = unsafe { act.next().unsafe_unwrap() };
+                let raw_byte = unsafe { act.next_unchecked_bytes() };
                 con.write_response(BytesWrapper(raw_byte)).await
             } else {
                 con.write_response(responses::groups::HEYA).await

--- a/server/src/actions/mpop.rs
+++ b/server/src/actions/mpop.rs
@@ -33,7 +33,7 @@ use crate::util::compiler;
 
 action!(
     /// Run an MPOP action
-    fn mpop(handle: &corestore::Corestore, con: &mut T, act: ActionIter) {
+    fn mpop(handle: &corestore::Corestore, con: &mut T, act: ActionIter<'a>) {
         err_if_len_is!(act, con, eq 0);
         if registry::state_okay() {
             let kve = kve!(con, handle);
@@ -41,7 +41,7 @@ action!(
                 true
             } else {
                 let encoder = kve.get_key_encoder();
-                act.as_ref().iter().all(|k| encoder.is_ok(k))
+                act.as_ref().all(|k| encoder.is_ok(k))
             };
             if compiler::likely(encoding_is_okay) {
                 let mut writer = unsafe {
@@ -50,7 +50,7 @@ action!(
                 }
                 .await?;
                 for key in act {
-                    match kve.pop_unchecked(&key) {
+                    match kve.pop_unchecked(key) {
                         Some((_key, val)) => writer.write_element(val).await?,
                         None => writer.write_null().await?,
                     }

--- a/server/src/actions/mset.rs
+++ b/server/src/actions/mset.rs
@@ -30,7 +30,7 @@ use crate::util::compiler;
 
 action!(
     /// Run an `MSET` query
-    fn mset(handle: &crate::corestore::Corestore, con: &mut T, mut act: ActionIter) {
+    fn mset(handle: &crate::corestore::Corestore, con: &mut T, mut act: ActionIter<'a>) {
         let howmany = act.len();
         if is_lowbit_set!(howmany) || howmany == 0 {
             // An odd number of arguments means that the number of keys
@@ -43,9 +43,9 @@ action!(
             true
         } else {
             let encoder = kve.get_encoder();
-            act.as_ref().chunks_exact(2).all(|kv| unsafe {
+            act.chunks_exact(2).all(|kv| unsafe {
                 let (k, v) = (kv.get_unchecked(0), kv.get_unchecked(1));
-                encoder.is_ok(k, v)
+                encoder.is_ok(k.as_slice(), v.as_slice())
             })
         };
         if compiler::likely(encoding_is_okay) {
@@ -53,7 +53,7 @@ action!(
             if registry::state_okay() {
                 let mut didmany = 0;
                 while let (Some(key), Some(val)) = (act.next(), act.next()) {
-                    if kve.set_unchecked(Data::from(key), Data::from(val)) {
+                    if kve.set_unchecked(Data::copy_from_slice(key), Data::copy_from_slice(val)) {
                         didmany += 1;
                     }
                 }

--- a/server/src/actions/pop.rs
+++ b/server/src/actions/pop.rs
@@ -29,16 +29,16 @@ use crate::resp::writer;
 use crate::util::compiler;
 
 action! {
-    fn pop(handle: &Corestore, con: &mut T, mut act: ActionIter) {
+    fn pop(handle: &Corestore, con: &'a mut T, mut act: ActionIter<'a>) {
         err_if_len_is!(act, con, not 1);
         let key = unsafe {
             // SAFETY: We have checked for there to be one arg
-            act.next().unsafe_unwrap()
+            act.next_unchecked()
         };
         if registry::state_okay() {
             let kve = kve!(con, handle);
             let tsymbol = kve.get_vt();
-            match kve.pop(&key) {
+            match kve.pop(key) {
                 Ok(Some((_key, val))) => unsafe {
                     // SAFETY: We have verified the tsymbol ourselves
                     writer::write_raw_mono(con, tsymbol, &val).await?

--- a/server/src/actions/set.rs
+++ b/server/src/actions/set.rs
@@ -36,7 +36,7 @@ use corestore::Data;
 
 action!(
     /// Run a `SET` query
-    fn set(handle: &crate::corestore::Corestore, con: &mut T, mut act: ActionIter) {
+    fn set(handle: &crate::corestore::Corestore, con: &mut T, mut act: ActionIter<'a>) {
         err_if_len_is!(act, con, not 2);
         if registry::state_okay() {
             let did_we = {
@@ -45,8 +45,8 @@ action!(
                     // UNSAFE(@ohsayan): This is completely safe as we've already checked
                     // that there are exactly 2 arguments
                     writer.set(
-                        Data::from(act.next().unsafe_unwrap()),
-                        Data::from(act.next().unsafe_unwrap()),
+                        Data::copy_from_slice(act.next().unsafe_unwrap()),
+                        Data::copy_from_slice(act.next().unsafe_unwrap()),
                     )
                 } {
                     Ok(true) => Some(true),

--- a/server/src/actions/strong/tests.rs
+++ b/server/src/actions/strong/tests.rs
@@ -37,7 +37,7 @@ mod sdel_concurrency_tests {
         kve.upsert(Data::from("k2"), Data::from("v2")).unwrap();
         let encoder = kve.get_key_encoder();
         let it = bi!("k1", "k2");
-        let ret = sdel::snapshot_and_del(&kve, encoder, it);
+        let ret = sdel::snapshot_and_del_test(&kve, encoder, it);
         assert!(ret.is_ok());
     }
     #[test]
@@ -51,7 +51,7 @@ mod sdel_concurrency_tests {
         }
         let it = bi!("k1", "k2");
         // sdel will wait 10s for us
-        let t1handle = thread::spawn(move || sdel::snapshot_and_del(&kve1, encoder, it));
+        let t1handle = thread::spawn(move || sdel::snapshot_and_del_test(&kve1, encoder, it));
         // we have 10s: we sleep 5 to let the snapshot complete (thread spawning takes time)
         do_sleep!(5 s);
         assert!(kve
@@ -77,7 +77,7 @@ mod sset_concurrency_tests {
         let kve = KVEngine::init(true, true);
         let encoder = kve.get_encoder();
         let it = bi!("k1", "v1", "k2", "v2");
-        let ret = sset::snapshot_and_insert(&kve, encoder, it);
+        let ret = sset::snapshot_and_insert_test(&kve, encoder, it);
         assert!(ret.is_ok());
     }
     #[test]
@@ -87,7 +87,7 @@ mod sset_concurrency_tests {
         let encoder = kve.get_encoder();
         let it = bi!("k1", "v1", "k2", "v2");
         // sset will wait 10s for us
-        let t1handle = thread::spawn(move || sset::snapshot_and_insert(&kve1, encoder, it));
+        let t1handle = thread::spawn(move || sset::snapshot_and_insert_test(&kve1, encoder, it));
         // we have 10s: we sleep 5 to let the snapshot complete (thread spawning takes time)
         do_sleep!(5 s);
         // update the value externally
@@ -119,7 +119,7 @@ mod supdate_concurrency_tests {
         kve.upsert(Data::from("k2"), Data::from("v2")).unwrap();
         let encoder = kve.get_encoder();
         let it = bi!("k1", "v1", "k2", "v2");
-        let ret = supdate::snapshot_and_update(&kve, encoder, it);
+        let ret = supdate::snapshot_and_update_test(&kve, encoder, it);
         assert!(ret.is_ok());
     }
     #[test]
@@ -131,7 +131,7 @@ mod supdate_concurrency_tests {
         let encoder = kve.get_encoder();
         let it = bi!("k1", "v1", "k2", "v2");
         // supdate will wait 10s for us
-        let t1handle = thread::spawn(move || supdate::snapshot_and_update(&kve1, encoder, it));
+        let t1handle = thread::spawn(move || supdate::snapshot_and_update_test(&kve1, encoder, it));
         // we have 10s: we sleep 5 to let the snapshot complete (thread spawning takes time)
         do_sleep!(5 s);
         // lets update the value externally

--- a/server/src/actions/update.rs
+++ b/server/src/actions/update.rs
@@ -43,8 +43,8 @@ action!(
                     // UNSAFE(@ohsayan): This is completely safe as we've already checked
                     // that there are exactly 2 arguments
                     writer.update(
-                        Data::copy_from_slice(act.next().unsafe_unwrap()),
-                        Data::copy_from_slice(act.next().unsafe_unwrap()),
+                        Data::copy_from_slice(act.next_unchecked()),
+                        Data::copy_from_slice(act.next_unchecked()),
                     )
                 } {
                     Ok(true) => Some(true),

--- a/server/src/actions/update.rs
+++ b/server/src/actions/update.rs
@@ -34,7 +34,7 @@ use crate::util::compiler;
 
 action!(
     /// Run an `UPDATE` query
-    fn update(handle: &Corestore, con: &mut T, mut act: ActionIter) {
+    fn update(handle: &Corestore, con: &'a mut T, mut act: ActionIter<'a>) {
         err_if_len_is!(act, con, not 2);
         if registry::state_okay() {
             let did_we = {
@@ -43,8 +43,8 @@ action!(
                     // UNSAFE(@ohsayan): This is completely safe as we've already checked
                     // that there are exactly 2 arguments
                     writer.update(
-                        Data::from(act.next().unsafe_unwrap()),
-                        Data::from(act.next().unsafe_unwrap()),
+                        Data::copy_from_slice(act.next().unsafe_unwrap()),
+                        Data::copy_from_slice(act.next().unsafe_unwrap()),
                     )
                 } {
                     Ok(true) => Some(true),

--- a/server/src/admin/mksnap.rs
+++ b/server/src/admin/mksnap.rs
@@ -32,7 +32,7 @@ use std::path::{Component, PathBuf};
 action!(
     /// Create a snapshot
     ///
-    fn mksnap(handle: &crate::corestore::Corestore, con: &mut T, mut act: ActionIter) {
+    fn mksnap(handle: &crate::corestore::Corestore, con: &mut T, mut act: ActionIter<'a>) {
         let engine = handle.get_engine();
         if act.len() == 0 {
             // traditional mksnap
@@ -47,7 +47,7 @@ action!(
             // remote snapshot, let's see what we've got
             let name = unsafe {
                 // SAFETY: We have already checked that there is one item
-                act.next().unsafe_unwrap()
+                act.next_unchecked_bytes()
             };
             if !encoding::is_utf8(&name) {
                 return conwrite!(con, groups::ENCODING_ERROR);

--- a/server/src/corestore/mod.rs
+++ b/server/src/corestore/mod.rs
@@ -349,7 +349,7 @@ impl Corestore {
                 con.flush_stream().await?;
             }
             // TODO(@ohsayan): Pipeline commands haven't been implemented yet
-            Query::PipelinedQuery(_) => {
+            Query::PipelineQuery(_) => {
                 con.write_response(responses::full_responses::R_PIPELINE_UNSUPPORTED)
                     .await?;
                 con.flush_stream().await?;

--- a/server/src/protocol/element.rs
+++ b/server/src/protocol/element.rs
@@ -24,24 +24,99 @@
  *
 */
 
+use super::UnsafeSlice;
+#[cfg(test)]
 use bytes::Bytes;
 
 #[non_exhaustive]
 #[derive(Debug, PartialEq)]
-/// # Data Types
+/// # Unsafe elements
+/// This enum represents the data types as **unsafe** elements, supported by the Skyhash Protocol
 ///
-/// This enum represents the data types supported by the Skyhash Protocol
-pub enum Element {
+/// ## Safety
+///
+/// The instantiator must ensure that the [`UnsafeSlice`]s are valid. See its own safety contracts
+/// for more information
+pub enum UnsafeElement {
     /// Arrays can be nested! Their `<tsymbol>` is `&`
-    Array(Vec<Element>),
+    Array(Box<[UnsafeElement]>),
     /// A String value; `<tsymbol>` is `+`
-    String(Bytes),
+    String(UnsafeSlice),
     /// An unsigned integer value; `<tsymbol>` is `:`
     UnsignedInt(u64),
     /// A non-recursive String array; tsymbol: `_`
-    FlatArray(Vec<Bytes>),
+    FlatArray(Box<[UnsafeFlatElement]>),
     /// A type-less non-recursive array
+    AnyArray(Box<[UnsafeSlice]>),
+}
+
+#[derive(Debug, PartialEq)]
+/// An **unsafe** flat element, present in a flat array
+pub enum UnsafeFlatElement {
+    String(UnsafeSlice),
+}
+
+// test impls are for our tests
+#[cfg(test)]
+impl UnsafeElement {
+    pub unsafe fn to_owned_flat_array(inner: &[UnsafeFlatElement]) -> Vec<FlatElement> {
+        inner
+            .iter()
+            .map(|v| match v {
+                UnsafeFlatElement::String(st) => {
+                    FlatElement::String(Bytes::copy_from_slice(st.as_slice()))
+                }
+            })
+            .collect()
+    }
+    pub unsafe fn to_owned_any_array(inner: &[UnsafeSlice]) -> Vec<Bytes> {
+        inner
+            .iter()
+            .map(|v| Bytes::copy_from_slice(v.as_slice()))
+            .collect()
+    }
+    pub unsafe fn to_owned_array(inner: &[Self]) -> Vec<OwnedElement> {
+        inner
+            .iter()
+            .map(|v| match &*v {
+                UnsafeElement::String(st) => {
+                    OwnedElement::String(Bytes::copy_from_slice(st.as_slice()))
+                }
+                UnsafeElement::UnsignedInt(int) => OwnedElement::UnsignedInt(*int),
+                UnsafeElement::AnyArray(arr) => {
+                    OwnedElement::AnyArray(Self::to_owned_any_array(arr))
+                }
+                UnsafeElement::Array(arr) => OwnedElement::Array(Self::to_owned_array(arr)),
+                UnsafeElement::FlatArray(frr) => {
+                    OwnedElement::FlatArray(Self::to_owned_flat_array(frr))
+                }
+            })
+            .collect()
+    }
+    pub unsafe fn as_owned_element(&self) -> OwnedElement {
+        match self {
+            Self::AnyArray(arr) => OwnedElement::AnyArray(Self::to_owned_any_array(arr)),
+            Self::FlatArray(frr) => OwnedElement::FlatArray(Self::to_owned_flat_array(frr)),
+            Self::Array(arr) => OwnedElement::Array(Self::to_owned_array(arr)),
+            Self::String(st) => OwnedElement::String(Bytes::copy_from_slice(st.as_slice())),
+            Self::UnsignedInt(int) => OwnedElement::UnsignedInt(*int),
+        }
+    }
+}
+
+// owned variants to simplify equality in tests
+#[derive(Debug, PartialEq)]
+#[cfg(test)]
+pub enum OwnedElement {
+    Array(Vec<OwnedElement>),
+    String(Bytes),
+    UnsignedInt(u64),
+    FlatArray(Vec<FlatElement>),
     AnyArray(Vec<Bytes>),
-    /// Swap the KS (ASCII `1A` (SUB HEADER))
-    SwapKSHeader(Bytes),
+}
+
+#[cfg(test)]
+#[derive(Debug, PartialEq)]
+pub enum FlatElement {
+    String(Bytes),
 }

--- a/server/src/protocol/iter.rs
+++ b/server/src/protocol/iter.rs
@@ -1,0 +1,137 @@
+/*
+ * Created on Sat Aug 21 2021
+ *
+ * This file is a part of Skytable
+ * Skytable (formerly known as TerrabaseDB or Skybase) is a free and open-source
+ * NoSQL database written by Sayan Nandan ("the Author") with the
+ * vision to provide flexibility in data modelling without compromising
+ * on performance, queryability or scalability.
+ *
+ * Copyright (c) 2021, Sayan Nandan <ohsayan@outlook.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+*/
+
+#[cfg(test)]
+use super::element::UnsafeElement;
+use super::UnsafeSlice;
+use bytes::Bytes;
+use core::hint::unreachable_unchecked;
+use core::iter::FusedIterator;
+use core::ops::Deref;
+use core::slice::ChunksExact;
+use core::slice::Iter;
+
+pub struct AnyArrayIter<'a> {
+    iter: Iter<'a, UnsafeSlice>,
+}
+
+pub struct BorrowedAnyArrayIter<'a> {
+    iter: Iter<'a, UnsafeSlice>,
+}
+
+impl<'a> Deref for BorrowedAnyArrayIter<'a> {
+    type Target = Iter<'a, UnsafeSlice>;
+    fn deref(&self) -> &Self::Target {
+        &self.iter
+    }
+}
+
+impl<'a> AnyArrayIter<'a> {
+    pub const unsafe fn new(iter: Iter<'a, UnsafeSlice>) -> AnyArrayIter<'a> {
+        Self { iter }
+    }
+    pub fn chunks_exact(&'a self, chunks_exact: usize) -> ChunksExact<'a, UnsafeSlice> {
+        self.iter.as_ref().chunks_exact(chunks_exact)
+    }
+    pub fn as_ref(&'a self) -> BorrowedAnyArrayIter<'a> {
+        BorrowedAnyArrayIter {
+            iter: self.iter.as_ref().iter(),
+        }
+    }
+    pub fn next_uppercase(&mut self) -> Option<Box<[u8]>> {
+        self.iter.next().map(|v| unsafe {
+            // SAFETY: Only construction is unsafe, forwarding is not
+            v.as_slice().to_ascii_uppercase().into_boxed_slice()
+        })
+    }
+    pub unsafe fn next_unchecked(&mut self) -> &'a [u8] {
+        match self.next() {
+            Some(s) => s,
+            None => unreachable_unchecked(),
+        }
+    }
+    pub unsafe fn next_unchecked_bytes(&mut self) -> Bytes {
+        Bytes::copy_from_slice(self.next_unchecked())
+    }
+}
+
+impl<'a> Iterator for AnyArrayIter<'a> {
+    type Item = &'a [u8];
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|v| unsafe { v.as_slice() })
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a> DoubleEndedIterator for AnyArrayIter<'a> {
+    fn next_back(&mut self) -> Option<<Self as Iterator>::Item> {
+        self.iter.next_back().map(|v| unsafe { v.as_slice() })
+    }
+}
+
+impl<'a> ExactSizeIterator for AnyArrayIter<'a> {}
+impl<'a> FusedIterator for AnyArrayIter<'a> {}
+
+impl<'a> Iterator for BorrowedAnyArrayIter<'a> {
+    type Item = &'a [u8];
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|v| unsafe { v.as_slice() })
+    }
+}
+
+impl<'a> DoubleEndedIterator for BorrowedAnyArrayIter<'a> {
+    fn next_back(&mut self) -> Option<<Self as Iterator>::Item> {
+        self.iter.next_back().map(|v| unsafe { v.as_slice() })
+    }
+}
+
+impl<'a> ExactSizeIterator for BorrowedAnyArrayIter<'a> {}
+impl<'a> FusedIterator for BorrowedAnyArrayIter<'a> {}
+
+#[test]
+fn test_iter() {
+    use super::{Parser, Query};
+    let (q, _fwby) = Parser::new(b"*1\n~3\n3\nset\n1\nx\n3\n100\n")
+        .parse()
+        .unwrap();
+    let r = match q {
+        Query::SimpleQuery(q) => q,
+        _ => panic!("Wrong query"),
+    };
+    let arr = unsafe {
+        match r.into_inner() {
+            UnsafeElement::AnyArray(arr) => arr,
+            _ => panic!("Wrong type"),
+        }
+    };
+    let it = arr.iter();
+    let mut iter =unsafe { AnyArrayIter::new(it)};
+    assert_eq!(iter.next_uppercase().unwrap().as_ref(), "SET".as_bytes());
+    assert_eq!(iter.next().unwrap(), "x".as_bytes());
+    assert_eq!(iter.next().unwrap(), "100".as_bytes());
+}

--- a/server/src/protocol/tests.rs
+++ b/server/src/protocol/tests.rs
@@ -1,0 +1,567 @@
+/*
+ * Created on Sat Aug 21 2021
+ *
+ * This file is a part of Skytable
+ * Skytable (formerly known as TerrabaseDB or Skybase) is a free and open-source
+ * NoSQL database written by Sayan Nandan ("the Author") with the
+ * vision to provide flexibility in data modelling without compromising
+ * on performance, queryability or scalability.
+ *
+ * Copyright (c) 2021, Sayan Nandan <ohsayan@outlook.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+*/
+
+use super::element::{FlatElement, OwnedElement};
+use super::{OwnedQuery, ParseError, Parser};
+use bytes::Bytes;
+
+#[test]
+fn test_read_line() {
+    let line = "abcdef\n".as_bytes();
+    let mut parser = Parser::new(line);
+    let retline = unsafe { parser.read_line().unwrap().to_owned() };
+    assert_eq!(retline, &line[..line.len() - 1]);
+    assert_eq!(parser.remaining(), 0);
+}
+
+#[test]
+fn test_read_until() {
+    let mybytes = "123456789".as_bytes();
+    let mut parser = Parser::new(mybytes);
+    let retline = unsafe { parser.read_until(7).unwrap().to_owned() };
+    assert_eq!(retline, &mybytes[..mybytes.len() - 2]);
+    assert_eq!(parser.remaining(), 2);
+}
+
+#[test]
+fn test_will_cursor_give_char() {
+    let mybytes = "\r\n".as_bytes();
+    let parser = Parser::new(mybytes);
+    assert!(parser.will_cursor_give_char(b'\r', false).unwrap());
+}
+
+#[test]
+fn test_will_cursor_give_linefeed() {
+    let mybytes = "\n".as_bytes();
+    let parser = Parser::new(mybytes);
+    assert!(parser.will_cursor_give_linefeed().unwrap());
+}
+
+#[test]
+fn test_will_cursor_give_linefeed_fail() {
+    let mybytes = "9\n".as_bytes();
+    let parser = Parser::new(mybytes);
+    assert!(!parser.will_cursor_give_linefeed().unwrap());
+}
+
+#[test]
+fn test_parse_into_usize() {
+    let bytes = "12345678".as_bytes();
+    let usz = Parser::parse_into_usize(bytes).unwrap();
+    assert_eq!(usz, 12345678);
+}
+
+#[test]
+fn test_parse_into_usize_fail() {
+    let bytes = "12345678ab".as_bytes();
+    let usze = Parser::parse_into_usize(bytes).unwrap_err();
+    assert_eq!(usze, ParseError::DatatypeParseFailure);
+}
+
+#[test]
+fn test_parse_into_u64() {
+    let bytes = "12345678".as_bytes();
+    let usz = Parser::parse_into_u64(bytes).unwrap();
+    assert_eq!(usz, 12345678);
+}
+
+#[test]
+fn test_parse_into_u64_fail() {
+    let bytes = "12345678ab".as_bytes();
+    let usze = Parser::parse_into_u64(bytes).unwrap_err();
+    assert_eq!(usze, ParseError::DatatypeParseFailure);
+}
+
+#[test]
+fn test_metaframe_parse_count() {
+    let bytes = "*1\n".as_bytes();
+    let mut parser = Parser::new(bytes);
+    assert_eq!(parser.parse_metaframe_get_datagroup_count().unwrap(), 1);
+    assert!(parser.remaining() == 0);
+    let bytes = "*10\n".as_bytes();
+    let mut parser = Parser::new(bytes);
+    assert_eq!(parser.parse_metaframe_get_datagroup_count().unwrap(), 10);
+    assert!(parser.remaining() == 0);
+}
+
+#[test]
+fn test_metaframe_parse_count_fail() {
+    let bytes = "*1A\n".as_bytes();
+    let mut parser = Parser::new(bytes);
+    assert_eq!(
+        parser.parse_metaframe_get_datagroup_count().unwrap_err(),
+        ParseError::DatatypeParseFailure
+    );
+    assert!(parser.remaining() == 0);
+    let bytes = "*10A\n".as_bytes();
+    let mut parser = Parser::new(bytes);
+    assert_eq!(
+        parser.parse_metaframe_get_datagroup_count().unwrap_err(),
+        ParseError::DatatypeParseFailure
+    );
+    assert!(parser.remaining() == 0);
+}
+
+#[test]
+fn test_next() {
+    let x = "5\nsayan\n".as_bytes();
+    let mut parser = Parser::new(x);
+    let ret = unsafe { parser._next().unwrap().to_owned() };
+    assert_eq!(ret, "sayan".as_bytes());
+    // WHY 1? Newline is not skipped
+    assert_eq!(parser.remaining(), 1);
+}
+
+#[test]
+fn test_next_fail() {
+    let x = "5\nsaya".as_bytes();
+    let mut parser = Parser::new(x);
+    let ret = parser._next().unwrap_err();
+    assert_eq!(ret, ParseError::NotEnough);
+}
+
+#[test]
+fn test_parse_next_string() {
+    let mystr = "+5\nsayan\n".as_bytes();
+    let mut parser = Parser::new(mystr);
+    // we do this since we skip `+`
+    parser.incr_cursor();
+    let st = unsafe { parser.parse_next_string().unwrap().to_owned() };
+    assert_eq!(st, "sayan".as_bytes());
+    // WHY 0? Because parse_next_<ty> forwards LF
+    assert_eq!(parser.remaining(), 0);
+}
+
+#[test]
+fn test_parse_next_string_fail() {
+    let mystr = "5\nsayan".as_bytes();
+    let mut parser = Parser::new(mystr);
+    let st = parser.parse_next_string().unwrap_err();
+    // NO LF, so not enough
+    assert_eq!(st, ParseError::NotEnough);
+}
+
+#[test]
+fn test_parse_next_u64() {
+    let myint = "5\n12345\n".as_bytes();
+    let mut parser = Parser::new(myint);
+    let int = parser.parse_next_u64().unwrap();
+    assert_eq!(int, 12345);
+}
+
+#[test]
+fn test_parse_next_u64_fail() {
+    let myint = "5\n12345".as_bytes();
+    let mut parser = Parser::new(myint);
+    let int = parser.parse_next_u64().unwrap_err();
+    assert_eq!(int, ParseError::NotEnough);
+}
+
+#[test]
+fn test_parse_next_null() {
+    let empty_buf = "".as_bytes();
+    assert_eq!(
+        Parser::new(empty_buf)._next().unwrap_err(),
+        ParseError::NotEnough
+    );
+}
+
+#[test]
+fn test_metaframe_parse() {
+    let metaframe = "*2\n".as_bytes();
+    let mut parser = Parser::new(metaframe);
+    assert_eq!(2, parser.parse_metaframe_get_datagroup_count().unwrap());
+}
+
+#[test]
+fn test_cursor_next_char() {
+    let bytes = &[b'\n'];
+    assert!(Parser::new(&bytes[..])
+        .will_cursor_give_char(b'\n', false)
+        .unwrap());
+    let bytes = &[];
+    assert!(Parser::new(&bytes[..])
+        .will_cursor_give_char(b'\r', true)
+        .unwrap());
+    let bytes = &[];
+    assert!(
+        Parser::new(&bytes[..])
+            .will_cursor_give_char(b'\n', false)
+            .unwrap_err()
+            == ParseError::NotEnough
+    );
+}
+
+#[test]
+fn test_metaframe_parse_fail() {
+    // First byte should be CR and not $
+    let metaframe = "$2\n*2\n".as_bytes();
+    let mut parser = Parser::new(metaframe);
+    assert_eq!(
+        parser.parse_metaframe_get_datagroup_count().unwrap_err(),
+        ParseError::UnexpectedByte
+    );
+    // Give a wrong length approximation
+    let metaframe = "\r1\n*2\n".as_bytes();
+    assert_eq!(
+        Parser::new(metaframe)
+            .parse_metaframe_get_datagroup_count()
+            .unwrap_err(),
+        ParseError::UnexpectedByte
+    );
+}
+
+#[test]
+fn test_query_fail_not_enough() {
+    let query_packet = "*".as_bytes();
+    assert_eq!(
+        Parser::new(query_packet).parse().err().unwrap(),
+        ParseError::NotEnough
+    );
+    let metaframe = "*2".as_bytes();
+    assert_eq!(
+        Parser::new(metaframe)
+            .parse_metaframe_get_datagroup_count()
+            .unwrap_err(),
+        ParseError::NotEnough
+    );
+}
+
+#[test]
+fn test_parse_next_u64_max() {
+    let max = 18446744073709551615;
+    assert!(u64::MAX == max);
+    let bytes = "20\n18446744073709551615\n".as_bytes();
+    let our_u64 = Parser::new(bytes).parse_next_u64().unwrap();
+    assert_eq!(our_u64, max);
+    // now overflow the u64
+    let bytes = "21\n184467440737095516156\n".as_bytes();
+    let our_u64 = Parser::new(bytes).parse_next_u64().unwrap_err();
+    assert_eq!(our_u64, ParseError::DatatypeParseFailure);
+}
+
+#[test]
+fn test_parse_next_element_string() {
+    let bytes = "+5\nsayan\n".as_bytes();
+    let next_element = Parser::new(bytes).parse_next_element().unwrap();
+    unsafe {
+        assert_eq!(
+            next_element.as_owned_element(),
+            OwnedElement::String(Bytes::from("sayan"))
+        );
+    }
+}
+
+#[test]
+fn test_parse_next_element_string_fail() {
+    let bytes = "+5\nsayan".as_bytes();
+    assert_eq!(
+        Parser::new(bytes).parse_next_element().unwrap_err(),
+        ParseError::NotEnough
+    );
+}
+
+#[test]
+fn test_parse_next_element_u64() {
+    let bytes = ":20\n18446744073709551615\n".as_bytes();
+    let our_u64 = unsafe {
+        Parser::new(bytes)
+            .parse_next_element()
+            .unwrap()
+            .as_owned_element()
+    };
+    assert_eq!(our_u64, OwnedElement::UnsignedInt(u64::MAX));
+}
+
+#[test]
+fn test_parse_next_element_u64_fail() {
+    let bytes = ":20\n18446744073709551615".as_bytes();
+    assert_eq!(
+        Parser::new(bytes).parse_next_element().unwrap_err(),
+        ParseError::NotEnough
+    );
+}
+
+#[test]
+fn test_parse_next_element_array() {
+    let bytes = "&3\n+4\nMGET\n+3\nfoo\n+3\nbar\n".as_bytes();
+    let mut parser = Parser::new(bytes);
+    let array = parser.parse_next_element().unwrap();
+    assert_eq!(
+        unsafe { array.as_owned_element() },
+        OwnedElement::Array(vec![
+            OwnedElement::String(Bytes::from("MGET".to_owned())),
+            OwnedElement::String(Bytes::from("foo".to_owned())),
+            OwnedElement::String(Bytes::from("bar".to_owned()))
+        ])
+    );
+    assert_eq!(parser.remaining(), 0);
+}
+
+#[test]
+fn test_parse_next_element_array_fail() {
+    // should've been three elements, but there are two!
+    let bytes = "&3\n+4\nMGET\n+3\nfoo\n+3\n".as_bytes();
+    let mut parser = Parser::new(bytes);
+    assert_eq!(
+        parser.parse_next_element().unwrap_err(),
+        ParseError::NotEnough
+    );
+}
+
+#[test]
+fn test_parse_nested_array() {
+    // let's test a nested array
+    let bytes =
+        "&3\n+3\nACT\n+3\nfoo\n&4\n+5\nsayan\n+2\nis\n+7\nworking\n&2\n+6\nreally\n+4\nhard\n"
+            .as_bytes();
+    let mut parser = Parser::new(bytes);
+    let array = parser.parse_next_element().unwrap();
+    assert_eq!(
+        unsafe { array.as_owned_element() },
+        OwnedElement::Array(vec![
+            OwnedElement::String(Bytes::from("ACT".to_owned())),
+            OwnedElement::String(Bytes::from("foo".to_owned())),
+            OwnedElement::Array(vec![
+                OwnedElement::String(Bytes::from("sayan".to_owned())),
+                OwnedElement::String(Bytes::from("is".to_owned())),
+                OwnedElement::String(Bytes::from("working".to_owned())),
+                OwnedElement::Array(vec![
+                    OwnedElement::String(Bytes::from("really".to_owned())),
+                    OwnedElement::String(Bytes::from("hard".to_owned()))
+                ])
+            ])
+        ])
+    );
+    assert_eq!(parser.remaining(), 0);
+}
+
+#[test]
+fn test_parse_multitype_array() {
+    // let's test a nested array
+    let bytes = "&3\n+3\nACT\n+3\nfoo\n&4\n+5\nsayan\n+2\nis\n+7\nworking\n&2\n:2\n23\n+5\napril\n"
+        .as_bytes();
+    let mut parser = Parser::new(bytes);
+    let array = parser.parse_next_element().unwrap();
+    assert_eq!(
+        unsafe { array.as_owned_element() },
+        OwnedElement::Array(vec![
+            OwnedElement::String(Bytes::from("ACT".to_owned())),
+            OwnedElement::String(Bytes::from("foo".to_owned())),
+            OwnedElement::Array(vec![
+                OwnedElement::String(Bytes::from("sayan".to_owned())),
+                OwnedElement::String(Bytes::from("is".to_owned())),
+                OwnedElement::String(Bytes::from("working".to_owned())),
+                OwnedElement::Array(vec![
+                    OwnedElement::UnsignedInt(23),
+                    OwnedElement::String(Bytes::from("april".to_owned()))
+                ])
+            ])
+        ])
+    );
+    assert_eq!(parser.remaining(), 0);
+}
+
+#[test]
+fn test_parse_a_query() {
+    let bytes =
+        "*1\n&3\n+3\nACT\n+3\nfoo\n&4\n+5\nsayan\n+2\nis\n+7\nworking\n&2\n:2\n23\n+5\napril\n"
+            .as_bytes();
+    let mut parser = Parser::new(bytes);
+    let (resp, _) = parser.parse().unwrap();
+    assert_eq!(
+        unsafe { resp.into_owned_query() },
+        OwnedQuery::SimpleQuery(OwnedElement::Array(vec![
+            OwnedElement::String(Bytes::from("ACT".to_owned())),
+            OwnedElement::String(Bytes::from("foo".to_owned())),
+            OwnedElement::Array(vec![
+                OwnedElement::String(Bytes::from("sayan".to_owned())),
+                OwnedElement::String(Bytes::from("is".to_owned())),
+                OwnedElement::String(Bytes::from("working".to_owned())),
+                OwnedElement::Array(vec![
+                    OwnedElement::UnsignedInt(23),
+                    OwnedElement::String(Bytes::from("april".to_owned()))
+                ])
+            ])
+        ]))
+    );
+    assert_eq!(parser.remaining(), 0);
+}
+
+#[test]
+fn test_parse_a_query_fail_moredata() {
+    let bytes =
+        "*1\n&3\n+3\nACT\n+3\nfoo\n&4\n+5\nsayan\n+2\nis\n+7\nworking\n&1\n:2\n23\n+5\napril\n"
+            .as_bytes();
+    let mut parser = Parser::new(bytes);
+    assert_eq!(parser.parse().unwrap_err(), ParseError::UnexpectedByte);
+}
+
+#[test]
+fn test_pipelined_query_incomplete() {
+    // this was a pipelined query: we expected two queries but got one!
+    let bytes =
+        "*2\n&3\n+3\nACT\n+3\nfoo\n&4\n+5\nsayan\n+2\nis\n+7\nworking\n&2\n:2\n23\n+5\napril\n"
+            .as_bytes();
+    assert_eq!(
+        Parser::new(bytes).parse().unwrap_err(),
+        ParseError::NotEnough
+    )
+}
+
+#[test]
+fn test_pipelined_query() {
+    let bytes =
+        "*2\n&3\n+3\nACT\n+3\nfoo\n&3\n+5\nsayan\n+2\nis\n+7\nworking\n+4\nHEYA\n".as_bytes();
+    /*
+    (\r2\n*2\n)(&3\n)({+3\nACT\n}{+3\nfoo\n}{[&3\n][+5\nsayan\n][+2\nis\n][+7\nworking\n]})(+4\nHEYA\n)
+    */
+    let (res, forward_by) = Parser::new(bytes).parse().unwrap();
+    assert_eq!(
+        unsafe { res.into_owned_query() },
+        OwnedQuery::PipelineQuery(vec![
+            OwnedElement::Array(vec![
+                OwnedElement::String(Bytes::from("ACT".to_owned())),
+                OwnedElement::String(Bytes::from("foo".to_owned())),
+                OwnedElement::Array(vec![
+                    OwnedElement::String(Bytes::from("sayan".to_owned())),
+                    OwnedElement::String(Bytes::from("is".to_owned())),
+                    OwnedElement::String(Bytes::from("working".to_owned()))
+                ])
+            ]),
+            OwnedElement::String(Bytes::from("HEYA".to_owned()))
+        ])
+    );
+    assert_eq!(forward_by, bytes.len());
+}
+
+#[test]
+fn test_query_with_part_of_next_query() {
+    let bytes =
+        "*1\n&3\n+3\nACT\n+3\nfoo\n&4\n+5\nsayan\n+2\nis\n+7\nworking\n&2\n:2\n23\n+5\napril\n*1\n"
+            .as_bytes();
+    let (res, forward_by) = Parser::new(bytes).parse().unwrap();
+    assert_eq!(
+        unsafe { res.into_owned_query() },
+        OwnedQuery::SimpleQuery(OwnedElement::Array(vec![
+            OwnedElement::String(Bytes::from("ACT".to_owned())),
+            OwnedElement::String(Bytes::from("foo".to_owned())),
+            OwnedElement::Array(vec![
+                OwnedElement::String(Bytes::from("sayan".to_owned())),
+                OwnedElement::String(Bytes::from("is".to_owned())),
+                OwnedElement::String(Bytes::from("working".to_owned())),
+                OwnedElement::Array(vec![
+                    OwnedElement::UnsignedInt(23),
+                    OwnedElement::String(Bytes::from("april".to_owned()))
+                ])
+            ])
+        ]))
+    );
+    // there are some ingenious folks on this planet who might just go bombing one query after the other
+    // we happily ignore those excess queries and leave it to the next round of parsing
+    assert_eq!(forward_by, bytes.len() - "*1\n".len());
+}
+
+#[test]
+fn test_parse_flat_array() {
+    let bytes = "_3\n+3\nSET\n+5\nHello\n+5\nWorld\n".as_bytes();
+    let res = Parser::new(bytes).parse_next_element().unwrap();
+    assert_eq!(
+        unsafe { res.as_owned_element() },
+        OwnedElement::FlatArray(vec![
+            FlatElement::String(Bytes::from("SET".to_owned())),
+            FlatElement::String(Bytes::from("Hello".to_owned())),
+            FlatElement::String(Bytes::from("World".to_owned()))
+        ])
+    );
+}
+
+#[test]
+fn test_flat_array_incomplete() {
+    let bytes = "*1\n_1\n".as_bytes();
+    let res = Parser::new(bytes).parse().unwrap_err();
+    assert_eq!(res, ParseError::NotEnough);
+    let bytes = "*1\n_1".as_bytes();
+    let res = Parser::new(bytes).parse().unwrap_err();
+    assert_eq!(res, ParseError::NotEnough);
+    let bytes = "*1\n_".as_bytes();
+    let res = Parser::new(bytes).parse().unwrap_err();
+    assert_eq!(res, ParseError::NotEnough);
+}
+
+#[test]
+fn test_array_incomplete() {
+    let bytes = "*1\n&1\n".as_bytes();
+    let res = Parser::new(bytes).parse().unwrap_err();
+    assert_eq!(res, ParseError::NotEnough);
+    let bytes = "*1\n&1".as_bytes();
+    let res = Parser::new(bytes).parse().unwrap_err();
+    assert_eq!(res, ParseError::NotEnough);
+    let bytes = "*1\n&".as_bytes();
+    let res = Parser::new(bytes).parse().unwrap_err();
+    assert_eq!(res, ParseError::NotEnough);
+}
+
+#[test]
+fn test_string_incomplete() {
+    let bytes = "*1\n+1\n".as_bytes();
+    let res = Parser::new(bytes).parse().unwrap_err();
+    assert_eq!(res, ParseError::NotEnough);
+    let bytes = "*1\n+1".as_bytes();
+    let res = Parser::new(bytes).parse().unwrap_err();
+    assert_eq!(res, ParseError::NotEnough);
+    let bytes = "*1\n+".as_bytes();
+    let res = Parser::new(bytes).parse().unwrap_err();
+    assert_eq!(res, ParseError::NotEnough);
+}
+
+#[test]
+fn test_u64_incomplete() {
+    let bytes = "*1\n:1\n".as_bytes();
+    let res = Parser::new(bytes).parse().unwrap_err();
+    assert_eq!(res, ParseError::NotEnough);
+    let bytes = "*1\n:1".as_bytes();
+    let res = Parser::new(bytes).parse().unwrap_err();
+    assert_eq!(res, ParseError::NotEnough);
+    let bytes = "*1\n:".as_bytes();
+    let res = Parser::new(bytes).parse().unwrap_err();
+    assert_eq!(res, ParseError::NotEnough);
+}
+
+#[test]
+fn test_parse_any_array() {
+    let anyarray = "*1\n~3\n3\nthe\n3\ncat\n6\nmeowed\n".as_bytes();
+    let (query, forward_by) = Parser::new(anyarray).parse().unwrap();
+    assert_eq!(forward_by, anyarray.len());
+    assert_eq!(
+        unsafe { query.into_owned_query() },
+        OwnedQuery::SimpleQuery(OwnedElement::AnyArray(vec![
+            "the".into(),
+            "cat".into(),
+            "meowed".into()
+        ]))
+    )
+}

--- a/server/src/queryengine/inspect.rs
+++ b/server/src/queryengine/inspect.rs
@@ -35,7 +35,7 @@ action! {
     /// - `INSPECT KEYSPACES` is run by this function itself
     /// - `INSPECT TABLE <tblid>` is delegated to self::inspect_table
     /// - `INSPECT KEYSPACE <ksid>` is delegated to self::inspect_keyspace
-    fn inspect(handle: &Corestore, con: &mut T, mut act: ActionIter) {
+    fn inspect(handle: &Corestore, con: &'a mut T, mut act: ActionIter<'a>) {
         match act.next() {
             Some(inspect_what) => {
                 let mut inspect_what = inspect_what.to_vec();
@@ -70,14 +70,14 @@ action! {
 
 action! {
     /// INSPECT a keyspace. This should only have the keyspace ID
-    fn inspect_keyspace(handle: &Corestore, con: &mut T, mut act: ActionIter) {
+    fn inspect_keyspace(handle: &Corestore, con: &'a mut T, mut act: ActionIter<'a>) {
         err_if_len_is!(act, con, not 1);
         match act.next() {
             Some(keyspace_name) => {
                 let ksid = if keyspace_name.len() > 64 {
                     return conwrite!(con, responses::groups::BAD_CONTAINER_NAME);
                 } else {
-                    &keyspace_name[..]
+                    keyspace_name
                 };
                 let ks = match handle.get_keyspace(ksid) {
                     Some(kspace) => kspace,
@@ -99,7 +99,7 @@ action! {
 
 action! {
     /// INSPECT a table. This should only have the table ID
-    fn inspect_table(handle: &Corestore, con: &mut T, mut act: ActionIter) {
+    fn inspect_table(handle: &Corestore, con: &'a mut T, mut act: ActionIter<'a>) {
         err_if_len_is!(act, con, not 1);
         match act.next() {
             Some(entity) => {

--- a/server/src/queryengine/mod.rs
+++ b/server/src/queryengine/mod.rs
@@ -33,7 +33,6 @@ use crate::protocol::element::UnsafeElement;
 use crate::protocol::iter::AnyArrayIter;
 use crate::protocol::responses;
 use crate::protocol::SimpleQuery;
-use crate::protocol::UnsafeSlice;
 use crate::{actions, admin};
 use core::hint::unreachable_unchecked;
 mod ddl;
@@ -53,11 +52,10 @@ macro_rules! gen_constants_and_matches {
                 pub const $action: &[u8] = stringify!($action).as_bytes();
             )*
         }
-        let mut first = match $buf.next_uppercase() {
+        let first = match $buf.next_uppercase() {
             Some(frst) => frst,
             None => return $con.write_response(responses::groups::PACKET_ERR).await,
         };
-        first.make_ascii_uppercase();
         match first.as_ref() {
             $(
                 tags::$action => $fns($db, $con, $buf).await?,
@@ -105,7 +103,7 @@ where
     if !buf.is_any_array() {
         return con.write_response(responses::groups::WRONGTYPE_ERR).await;
     }
-    let bufref: Box<[UnsafeSlice]>;
+    let bufref;
     let _rawiter;
     let mut iter;
     unsafe {
@@ -165,7 +163,7 @@ action! {
         err_if_len_is!(act, con, not 1);
         let entity = unsafe {
             // SAFETY: Already checked len
-            act.next().unsafe_unwrap()
+            act.next_unchecked()
         };
         swap_entity!(con, handle, entity);
         Ok(())

--- a/server/src/queryengine/mod.rs
+++ b/server/src/queryengine/mod.rs
@@ -29,21 +29,23 @@
 use crate::corestore::memstore::DdlError;
 use crate::corestore::Corestore;
 use crate::dbnet::connection::prelude::*;
+use crate::protocol::element::UnsafeElement;
+use crate::protocol::iter::AnyArrayIter;
 use crate::protocol::responses;
-use crate::protocol::Element;
+use crate::protocol::SimpleQuery;
+use crate::protocol::UnsafeSlice;
 use crate::{actions, admin};
-use bytes::Bytes;
+use core::hint::unreachable_unchecked;
 mod ddl;
 mod inspect;
 pub mod parser;
 #[cfg(test)]
 mod tests;
 
-use std::vec::IntoIter;
-pub type ActionIter = IntoIter<Bytes>;
+pub type ActionIter<'a> = AnyArrayIter<'a>;
 
 macro_rules! gen_constants_and_matches {
-    ($con:ident, $buf:ident, $db:ident, $($action:ident => $fns:expr),*) => {
+    ($con:expr, $buf:ident, $db:ident, $($action:ident => $fns:expr),*) => {
         mod tags {
             //! This module is a collection of tags/strings used for evaluating queries
             //! and responses
@@ -51,8 +53,8 @@ macro_rules! gen_constants_and_matches {
                 pub const $action: &[u8] = stringify!($action).as_bytes();
             )*
         }
-        let mut first = match $buf.next() {
-            Some(frst) => frst.to_vec(),
+        let mut first = match $buf.next_uppercase() {
+            Some(frst) => frst,
             None => return $con.write_response(responses::groups::PACKET_ERR).await,
         };
         first.make_ascii_uppercase();
@@ -61,7 +63,7 @@ macro_rules! gen_constants_and_matches {
                 tags::$action => $fns($db, $con, $buf).await?,
             )*
             _ => {
-                return $con.write_response(responses::groups::UNKNOWN_ACTION).await;
+                $con.write_response(responses::groups::UNKNOWN_ACTION).await?;
             }
         }
     };
@@ -91,53 +93,75 @@ macro_rules! swap_entity {
 }
 
 /// Execute a simple(*) query
-pub async fn execute_simple<T, Strm>(
+pub async fn execute_simple<'a, T: 'a, Strm>(
     db: &mut Corestore,
-    con: &mut T,
-    buf: Element,
+    con: &'a mut T,
+    buf: SimpleQuery,
 ) -> std::io::Result<()>
 where
     T: ProtocolConnectionExt<Strm>,
     Strm: AsyncReadExt + AsyncWriteExt + Unpin + Send + Sync,
 {
-    let buf = match buf {
-        Element::AnyArray(a) => a,
-        _ => return con.write_response(responses::groups::WRONGTYPE_ERR).await,
-    };
-    let mut buf = buf.into_iter();
-    gen_constants_and_matches!(
-        con, buf, db,
-        GET => actions::get::get,
-        SET => actions::set::set,
-        UPDATE => actions::update::update,
-        DEL => actions::del::del,
-        HEYA => actions::heya::heya,
-        EXISTS => actions::exists::exists,
-        MSET => actions::mset::mset,
-        MGET => actions::mget::mget,
-        MUPDATE => actions::mupdate::mupdate,
-        SSET => actions::strong::sset,
-        SDEL => actions::strong::sdel,
-        SUPDATE => actions::strong::supdate,
-        DBSIZE => actions::dbsize::dbsize,
-        FLUSHDB => actions::flushdb::flushdb,
-        USET => actions::uset::uset,
-        KEYLEN => actions::keylen::keylen,
-        MKSNAP => admin::mksnap::mksnap,
-        LSKEYS => actions::lskeys::lskeys,
-        POP => actions::pop::pop,
-        CREATE => ddl::create,
-        DROP => ddl::ddl_drop,
-        USE => self::entity_swap,
-        INSPECT => inspect::inspect,
-        MPOP => actions::mpop::mpop
-    );
+    if !buf.is_any_array() {
+        return con.write_response(responses::groups::WRONGTYPE_ERR).await;
+    }
+    let bufref: Box<[UnsafeSlice]>;
+    let _rawiter;
+    let mut iter;
+    unsafe {
+        // this is the boxed slice
+        bufref = {
+            // SAFETY: execute_simple is called by execute_query which in turn is called
+            // by ConnnectionHandler::run(). In all cases, the `Con` remains valid
+            // ensuring that the source buffer exists as long as the connection does
+            // so this is safe.
+            match buf.into_inner() {
+                UnsafeElement::AnyArray(arr) => arr,
+                _ => unreachable_unchecked(),
+            }
+        };
+        _rawiter = bufref.iter();
+        // this is our final iter
+        iter = {
+            // SAFETY: Again, this is guaranteed to be valid because the `con` is valid
+            AnyArrayIter::new(_rawiter)
+        };
+    }
+    {
+        gen_constants_and_matches!(
+            con, iter, db,
+            GET => actions::get::get,
+            SET => actions::set::set,
+            UPDATE => actions::update::update,
+            DEL => actions::del::del,
+            HEYA => actions::heya::heya,
+            EXISTS => actions::exists::exists,
+            MSET => actions::mset::mset,
+            MGET => actions::mget::mget,
+            MUPDATE => actions::mupdate::mupdate,
+            SSET => actions::strong::sset,
+            SDEL => actions::strong::sdel,
+            SUPDATE => actions::strong::supdate,
+            DBSIZE => actions::dbsize::dbsize,
+            FLUSHDB => actions::flushdb::flushdb,
+            USET => actions::uset::uset,
+            KEYLEN => actions::keylen::keylen,
+            MKSNAP => admin::mksnap::mksnap,
+            LSKEYS => actions::lskeys::lskeys,
+            POP => actions::pop::pop,
+            CREATE => ddl::create,
+            DROP => ddl::ddl_drop,
+            USE => self::entity_swap,
+            INSPECT => inspect::inspect,
+            MPOP => actions::mpop::mpop
+        );
+    }
     Ok(())
 }
 
 action! {
     /// Handle `use <entity>` like queries
-    fn entity_swap(handle: &mut Corestore, con: &mut T, mut act: ActionIter) {
+    fn entity_swap(handle: &mut Corestore, con: &mut T, mut act: ActionIter<'a>) {
         err_if_len_is!(act, con, not 1);
         let entity = unsafe {
             // SAFETY: Already checked len

--- a/server/src/queryengine/parser.rs
+++ b/server/src/queryengine/parser.rs
@@ -50,6 +50,92 @@ pub(super) fn parse_table_args(
     if compiler::unlikely(!encoding::is_utf8(&table_name) || !encoding::is_utf8(&model_name)) {
         return Err(responses::groups::ENCODING_ERROR);
     }
+    let model_name_str = unsafe { str::from_utf8_unchecked(model_name) };
+
+    // get the entity group
+    let entity_group = get_query_entity(table_name)?;
+    let splits: Vec<&str> = model_name_str.split('(').collect();
+    if compiler::unlikely(splits.len() != 2) {
+        return Err(responses::groups::BAD_EXPRESSION);
+    }
+    let model_name_split = unsafe { splits.get_unchecked(0) };
+    let model_args_split = unsafe { splits.get_unchecked(1) };
+
+    // model name has to have at least one char while model args should have
+    // atleast `)` 1 chars (for example if the model takes no arguments: `smh()`)
+    if compiler::unlikely(model_name_split.is_empty() || model_args_split.is_empty()) {
+        return Err(responses::groups::BAD_EXPRESSION);
+    }
+
+    // THIS IS WHERE WE HANDLE THE NEWER MODELS
+    if model_name_split.as_bytes() != KEYMAP {
+        return Err(responses::groups::UNKNOWN_MODEL);
+    }
+
+    let non_bracketed_end = unsafe {
+        *model_args_split
+            .as_bytes()
+            .get_unchecked(model_args_split.len() - 1)
+            != b')'
+    };
+
+    if compiler::unlikely(non_bracketed_end) {
+        return Err(responses::groups::BAD_EXPRESSION);
+    }
+
+    // should be (ty1, ty2)
+    let model_args: Vec<&str> = model_args_split[..model_args_split.len() - 1]
+        .split(',')
+        .map(|v| v.trim())
+        .collect();
+    if compiler::unlikely(model_args.len() != 2) {
+        // nope, someone had fun with commas or they added more args
+        // let's check if it was comma fun or if it was arg fun
+        return cold_err({
+            let all_nonzero = model_args.into_iter().all(|v| !v.is_empty());
+            if all_nonzero {
+                // arg fun
+                Err(responses::groups::TOO_MANY_ARGUMENTS)
+            } else {
+                // comma fun
+                Err(responses::groups::BAD_EXPRESSION)
+            }
+        });
+    }
+    let key_ty = unsafe { model_args.get_unchecked(0) };
+    let val_ty = unsafe { model_args.get_unchecked(1) };
+    if compiler::unlikely(
+        !VALID_CONTAINER_NAME.is_match(key_ty) || !VALID_CONTAINER_NAME.is_match(val_ty),
+    ) {
+        return Err(responses::groups::BAD_EXPRESSION);
+    }
+    let key_ty = key_ty.as_bytes();
+    let val_ty = val_ty.as_bytes();
+    let model_code: u8 = match (key_ty, val_ty) {
+        (BINSTR, BINSTR) => 0,
+        (BINSTR, STR) => 1,
+        (STR, STR) => 2,
+        (STR, BINSTR) => 3,
+        _ => return Err(responses::groups::UNKNOWN_DATA_TYPE),
+    };
+    Ok((
+        unsafe {
+            // SAFETY: All sizes checked here
+            entity_group.into_owned()
+        },
+        model_code,
+    ))
+}
+
+#[cfg(test)]
+pub(super) fn parse_table_args_test(
+    act: &mut std::vec::IntoIter<bytes::Bytes>,
+) -> Result<(OwnedEntityGroup, u8), &'static [u8]> {
+    let table_name = unsafe { act.next().unsafe_unwrap() };
+    let model_name = unsafe { act.next().unsafe_unwrap() };
+    if compiler::unlikely(!encoding::is_utf8(&table_name) || !encoding::is_utf8(&model_name)) {
+        return Err(responses::groups::ENCODING_ERROR);
+    }
     let model_name_str = unsafe { str::from_utf8_unchecked(&model_name) };
 
     // get the entity group
@@ -126,7 +212,6 @@ pub(super) fn parse_table_args(
         model_code,
     ))
 }
-
 pub fn get_query_entity<'a>(input: &'a [u8]) -> Result<BorrowedEntityGroup, &'static [u8]> {
     let y: Vec<&[u8]> = input.split(|v| *v == b':').collect();
     unsafe {

--- a/server/src/queryengine/tests.rs
+++ b/server/src/queryengine/tests.rs
@@ -27,35 +27,35 @@
 use super::parser;
 
 mod parser_ddl_tests {
-    use super::parser::parse_table_args;
+    use super::parser::parse_table_args_test;
     use crate::corestore::memstore::ObjectID;
     use crate::protocol::responses;
     #[test]
     fn test_table_args_valid() {
         // create table [mytbl keymap(str, str)]
         let mut it = vec![byt!("mytbl"), byt!("keymap(binstr,binstr)")].into_iter();
-        let (tbl_name, mcode) = parse_table_args(&mut it).unwrap();
+        let (tbl_name, mcode) = parse_table_args_test(&mut it).unwrap();
         assert_eq!(tbl_name, unsafe {
             (Some(ObjectID::from_slice("mytbl")), None)
         });
         assert_eq!(mcode, 0);
 
         let mut it = vec![byt!("mytbl"), byt!("keymap(binstr,str)")].into_iter();
-        let (tbl_name, mcode) = parse_table_args(&mut it).unwrap();
+        let (tbl_name, mcode) = parse_table_args_test(&mut it).unwrap();
         assert_eq!(tbl_name, unsafe {
             (Some(ObjectID::from_slice("mytbl")), None)
         });
         assert_eq!(mcode, 1);
 
         let mut it = vec![byt!("mytbl"), byt!("keymap(str,str)")].into_iter();
-        let (tbl_name, mcode) = parse_table_args(&mut it).unwrap();
+        let (tbl_name, mcode) = parse_table_args_test(&mut it).unwrap();
         assert_eq!(tbl_name, unsafe {
             (Some(ObjectID::from_slice("mytbl")), None)
         });
         assert_eq!(mcode, 2);
 
         let mut it = vec![byt!("mytbl"), byt!("keymap(str,binstr)")].into_iter();
-        let (tbl_name, mcode) = parse_table_args(&mut it).unwrap();
+        let (tbl_name, mcode) = parse_table_args_test(&mut it).unwrap();
         assert_eq!(tbl_name, unsafe {
             (Some(ObjectID::from_slice("mytbl")), None)
         });
@@ -65,40 +65,40 @@ mod parser_ddl_tests {
     fn test_table_bad_ident() {
         let mut it = vec![byt!("1one"), byt!("keymap(binstr,binstr)")].into_iter();
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_CONTAINER_NAME
         );
         let mut it = vec![byt!("%whywouldsomeone"), byt!("keymap(binstr,binstr)")].into_iter();
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_CONTAINER_NAME
         );
     }
     #[test]
     fn test_table_whitespaced_datatypes() {
         let mut it = vec![byt!("mycooltbl"), byt!("keymap(binstr, binstr)")].into_iter();
-        let (tblid, mcode) = parse_table_args(&mut it).unwrap();
+        let (tblid, mcode) = parse_table_args_test(&mut it).unwrap();
         assert_eq!(tblid, unsafe {
             (Some(ObjectID::from_slice("mycooltbl")), None)
         });
         assert_eq!(mcode, 0);
 
         let mut it = vec![byt!("mycooltbl"), byt!("keymap(binstr, str)")].into_iter();
-        let (tblid, mcode) = parse_table_args(&mut it).unwrap();
+        let (tblid, mcode) = parse_table_args_test(&mut it).unwrap();
         assert_eq!(tblid, unsafe {
             (Some(ObjectID::from_slice("mycooltbl")), None)
         });
         assert_eq!(mcode, 1);
 
         let mut it = vec![byt!("mycooltbl"), byt!("keymap(str, str)")].into_iter();
-        let (tblid, mcode) = parse_table_args(&mut it).unwrap();
+        let (tblid, mcode) = parse_table_args_test(&mut it).unwrap();
         assert_eq!(tblid, unsafe {
             (Some(ObjectID::from_slice("mycooltbl")), None)
         });
         assert_eq!(mcode, 2);
 
         let mut it = vec![byt!("mycooltbl"), byt!("keymap(str, binstr)")].into_iter();
-        let (tblid, mcode) = parse_table_args(&mut it).unwrap();
+        let (tblid, mcode) = parse_table_args_test(&mut it).unwrap();
         assert_eq!(tblid, unsafe {
             (Some(ObjectID::from_slice("mycooltbl")), None)
         });
@@ -109,22 +109,22 @@ mod parser_ddl_tests {
     fn test_table_badty() {
         let mut it = vec![byt!("mycooltbl"), byt!("keymap(wth, str)")].into_iter();
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::UNKNOWN_DATA_TYPE
         );
         let mut it = vec![byt!("mycooltbl"), byt!("keymap(wth, wth)")].into_iter();
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::UNKNOWN_DATA_TYPE
         );
         let mut it = vec![byt!("mycooltbl"), byt!("keymap(str, wth)")].into_iter();
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::UNKNOWN_DATA_TYPE
         );
         let mut it = vec![byt!("mycooltbl"), byt!("keymap(wth1, wth2)")].into_iter();
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::UNKNOWN_DATA_TYPE
         );
     }
@@ -132,17 +132,17 @@ mod parser_ddl_tests {
     fn test_table_bad_model() {
         let mut it = vec![byt!("mycooltbl"), byt!("wthmap(wth, wth)")].into_iter();
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::UNKNOWN_MODEL
         );
         let mut it = vec![byt!("mycooltbl"), byt!("wthmap(str, str)")].into_iter();
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::UNKNOWN_MODEL
         );
         let mut it = vec![byt!("mycooltbl"), byt!("wthmap()")].into_iter();
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::UNKNOWN_MODEL
         );
     }
@@ -150,82 +150,82 @@ mod parser_ddl_tests {
     fn test_table_malformed_expr() {
         let mut it = bi!("mycooltbl", "keymap(");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap(,");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap(,,");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap),");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap),,");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap),,)");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap(,)");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap(,,)");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap,");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap,,");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap,,)");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap(str,");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap(str,str");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap(str,str,");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap(str,str,)");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
         let mut it = bi!("mycooltbl", "keymap(str,str,),");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::BAD_EXPRESSION
         );
     }
@@ -234,14 +234,14 @@ mod parser_ddl_tests {
     fn test_table_too_many_args() {
         let mut it = bi!("mycooltbl", "keymap(str, str, str)");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::TOO_MANY_ARGUMENTS
         );
 
         // this should be valid for not-yet-known data types too
         let mut it = bi!("mycooltbl", "keymap(wth, wth, wth)");
         assert_eq!(
-            parse_table_args(&mut it).unwrap_err(),
+            parse_table_args_test(&mut it).unwrap_err(),
             responses::groups::TOO_MANY_ARGUMENTS
         );
     }

--- a/server/src/util.rs
+++ b/server/src/util.rs
@@ -154,7 +154,7 @@ macro_rules! action {
         $block:block
     ) => {
             $(#[$attr])*
-            pub async fn $fname<T, Strm>($($argname: $argty,)*) -> std::io::Result<()>
+            pub async fn $fname<'a, T: 'a, Strm>($($argname: $argty,)*) -> std::io::Result<()>
             where
                 T: ProtocolConnectionExt<Strm>,
                 Strm: AsyncReadExt + AsyncWriteExt + Unpin + Send + Sync,
@@ -166,7 +166,7 @@ macro_rules! action {
         $block:block
     ) => {
             $(#[$attr])*
-            pub async fn $fname<T, Strm>($argone: $argonety, $argtwo: $argtwoty, mut $argthree: $argthreety) -> std::io::Result<()>
+            pub async fn $fname<'a, T: 'a, Strm>($argone: $argonety, $argtwo: $argtwoty, mut $argthree: $argthreety) -> std::io::Result<()>
             where
                 T: ProtocolConnectionExt<Strm>,
                 Strm: AsyncReadExt + AsyncWriteExt + Unpin + Send + Sync,


### PR DESCRIPTION
This PR aims to reduce the number of unnecessary explicit copies that happen, and it achieves this by using a lot of raw pointers -- but again, we uphold guarantees as and when required.

## Allocations per second
### Old
![old-allocpersec](https://user-images.githubusercontent.com/17377258/130396715-7421977f-3bbb-491f-897b-2f2c9b4cd427.png)
### New
![new-allocpersec](https://user-images.githubusercontent.com/17377258/130396727-0ec729d7-bf18-4726-a673-a0d9f08f8cd3.png)

## Live allocations
### Old
![old-lalloc](https://user-images.githubusercontent.com/17377258/130396912-5e7b6325-7546-4f17-8ef7-ec7b40c597da.png)
### New
![new-lalloc](https://user-images.githubusercontent.com/17377258/130396926-9f63e828-a602-4608-8caf-6f65289f505f.png)

To summarize, this provides much more consistent performance.