### PR TITLE
fix actiondoc for MGET and MPOP

### DIFF
--- a/actiondoc.yml
+++ b/actiondoc.yml
@@ -129,11 +129,11 @@
 - name: MKSNAP
   complexity: O(n)
   accept: [AnyArray]
-  syntax: [MKSNAP <SNAPNAME>]
+  syntax: [MKSNAP, MKSNAP <SNAPNAME>]
   desc: |
-    This action can be used to create a snapshot. Do note that this action **requires
-    snapshotting to be enabled on the server side**, before it can create snapshots.
-    If you want to create snapshots **without** snapshots being enabled on the server-side,
+    This action can be used to create a snapshot. Do note that this action requires
+    snapshotting to be enabled on the server side, before it can create snapshots.
+    If you want to create snapshots without snapshots being enabled on the server-side,
     pass a second argument <SNAPNAME> to specify a snapshot name and a snapshot will
     be create in a folder called `remote` under your snapshots directory. For more
     information on snapshots, read [this document](/snapshots)


### PR DESCRIPTION
bold has been removed for now since it is not displayed correctly and MKSNAP is the only action that uses it.