### PR TITLE
Improve terminal I/O in skysh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All changes in this project will be noted in this file.
 
+## Unreleased
+
+### Improvements
+
+- `skysh` now handles special character strings more reliably
+- `skysh` now supports splitting a command across multiple lines
+
 ## Version 0.7.1
 
 ### Additions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,9 +471,6 @@ checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 name = "libsky"
 version = "0.7.1"
 dependencies = [
- "lazy_static",
- "regex",
- "skytable 0.6.0 (git+https://github.com/skytable/client-rust?branch=next)",
  "termcolor",
 ]
 

--- a/cli/src/argparse.rs
+++ b/cli/src/argparse.rs
@@ -83,11 +83,11 @@ macro_rules! inner_repl {
                                 Ok(l) => l,
                                 Err(ReadlineError::Interrupted) => break,
                                 Err(err) => {
-                                    eprintln!("Failed to read line with error: {}", err);
+                                    eprintln!("ERROR: Failed to read line with error: {}", err);
                                     exit(1);
                                 }
                             };
-                            line = line.trim_end_matches(r#" \"#).to_string();
+                            line = line[line.len() - 2..].to_string();
                             line.extend(cl.chars());
                         }
                         $runner.run_query(&line).await
@@ -95,13 +95,13 @@ macro_rules! inner_repl {
                 },
                 Err(ReadlineError::Interrupted) => break,
                 Err(err) => {
-                    eprintln!("Failed to read line with error: {}", err);
+                    eprintln!("ERROR: Failed to read line with error: {}", err);
                     exit(1);
                 }
             }
         }
         if let Err(e) = editor.save_history(".sky_history") {
-            eprintln!("Failed to save history with error: '{}'", e);
+            eprintln!("ERROR: Failed to save history with error: '{}'", e);
         }
     };
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -30,6 +30,9 @@
 mod argparse;
 mod runner;
 mod tokenizer;
+// tests
+#[cfg(test)]
+mod tests;
 
 #[tokio::main]
 async fn main() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,6 +29,7 @@
 
 mod argparse;
 mod runner;
+mod tokenizer;
 
 #[tokio::main]
 async fn main() {

--- a/cli/src/tests.rs
+++ b/cli/src/tests.rs
@@ -1,0 +1,131 @@
+/*
+ * Created on Sun Oct 10 2021
+ *
+ * This file is a part of Skytable
+ * Skytable (formerly known as TerrabaseDB or Skybase) is a free and open-source
+ * NoSQL database written by Sayan Nandan ("the Author") with the
+ * vision to provide flexibility in data modelling without compromising
+ * on performance, queryability or scalability.
+ *
+ * Copyright (c) 2021, Sayan Nandan <ohsayan@outlook.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+*/
+
+use crate::tokenizer::get_query;
+
+#[test]
+fn test_basic_tokenization() {
+    let input = "set x 100".as_bytes();
+    let ret: Vec<String> = get_query(input).unwrap();
+    assert_eq!(
+        ret,
+        vec!["set".to_owned(), "x".to_owned(), "100".to_owned()]
+    );
+}
+
+#[test]
+fn test_single_quote_tokens() {
+    let input = "set 'x with a whitespace' 100".as_bytes();
+    let ret: Vec<String> = get_query(input).unwrap();
+    assert_eq!(
+        ret,
+        vec![
+            "set".to_owned(),
+            "x with a whitespace".to_owned(),
+            "100".to_owned()
+        ]
+    );
+}
+
+#[test]
+fn test_double_quote_tokens() {
+    let input = r#"set "x with a whitespace" 100"#.as_bytes();
+    let ret: Vec<String> = get_query(input).unwrap();
+    assert_eq!(
+        ret,
+        vec![
+            "set".to_owned(),
+            "x with a whitespace".to_owned(),
+            "100".to_owned()
+        ]
+    );
+}
+
+#[test]
+fn test_single_and_double_quote_tokens() {
+    let input = r#"set "x with a whitespace" 'y with a whitespace'"#.as_bytes();
+    let ret: Vec<String> = get_query(input).unwrap();
+    assert_eq!(
+        ret,
+        vec![
+            "set".to_owned(),
+            "x with a whitespace".to_owned(),
+            "y with a whitespace".to_owned()
+        ]
+    );
+}
+
+#[test]
+fn test_multiple_single_quote_tokens() {
+    let input = r#"'set' 'x with a whitespace' 'y with a whitespace'"#.as_bytes();
+    let ret: Vec<String> = get_query(input).unwrap();
+    assert_eq!(
+        ret,
+        vec![
+            "set".to_owned(),
+            "x with a whitespace".to_owned(),
+            "y with a whitespace".to_owned()
+        ]
+    );
+}
+
+#[test]
+fn test_multiple_double_quote_tokens() {
+    let input = r#""set" "x with a whitespace" "y with a whitespace""#.as_bytes();
+    let ret: Vec<String> = get_query(input).unwrap();
+    assert_eq!(
+        ret,
+        vec![
+            "set".to_owned(),
+            "x with a whitespace".to_owned(),
+            "y with a whitespace".to_owned()
+        ]
+    );
+}
+
+#[test]
+fn test_missing_single_quote() {
+    let input = r#"'get' 'x with a whitespace"#.as_bytes();
+    let ret = format!("{}", get_query::<Vec<String>>(input).unwrap_err());
+    assert_eq!(ret, "mismatched quotes near end of: `x with a whitespace`");
+}
+
+#[test]
+fn test_missing_double_quote() {
+    let input = r#"'get' "x with a whitespace"#.as_bytes();
+    let ret = format!("{}", get_query::<Vec<String>>(input).unwrap_err());
+    assert_eq!(ret, "mismatched quotes near end of: `x with a whitespace`");
+}
+
+#[test]
+fn test_extra_whitespace() {
+    let input = "set  x  '100'".as_bytes();
+    let ret = get_query::<Vec<String>>(input).unwrap();
+    assert_eq!(
+        ret,
+        vec!["set".to_owned(), "x".to_owned(), "100".to_owned()]
+    );
+}

--- a/cli/src/tests.rs
+++ b/cli/src/tests.rs
@@ -24,7 +24,7 @@
  *
 */
 
-use crate::tokenizer::get_query;
+use crate::tokenizer::{get_query, TokenizerError};
 
 #[test]
 fn test_basic_tokenization() {
@@ -128,4 +128,11 @@ fn test_extra_whitespace() {
         ret,
         vec!["set".to_owned(), "x".to_owned(), "100".to_owned()]
     );
+}
+
+#[test]
+fn test_singly_quoted() {
+    let input = "set tables' wth".as_bytes();
+    let ret = get_query::<Vec<String>>(input).unwrap_err();
+    assert_eq!(ret, TokenizerError::QuoteMismatch(" wth".to_owned()));
 }

--- a/cli/src/tokenizer.rs
+++ b/cli/src/tokenizer.rs
@@ -34,14 +34,12 @@ use skytable::{types::RawString, Query};
 #[derive(Debug)]
 pub enum TokenizerError {
     QuoteMismatch(String),
-    BadExpression(String),
 }
 
 impl fmt::Display for TokenizerError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::QuoteMismatch(expr) => write!(f, "mismatched quotes near end of: `{}`", expr),
-            Self::BadExpression(expr) => write!(f, "bad expression near end of: `{}`", expr),
         }
     }
 }
@@ -51,7 +49,6 @@ pub trait SequentialQuery {
     fn new() -> Self;
 }
 
-#[cfg(test)]
 impl SequentialQuery for Vec<String> {
     fn push(&mut self, input: &[u8]) {
         Vec::push(self, String::from_utf8_lossy(input).to_string())
@@ -83,12 +80,6 @@ pub fn get_query<T: SequentialQuery>(inp: &[u8]) -> Result<T, TokenizerError> {
     }
     while let Some(tok) = it.next() {
         match tok {
-            // numbers? nope
-            b'0'..=b'9' => {
-                return Err(TokenizerError::BadExpression(
-                    String::from_utf8_lossy(&inp[..pos!()]).to_string(),
-                ));
-            }
             b'\'' => {
                 // hmm, quotes; let's see where it ends
                 let pos = pos!();

--- a/cli/src/tokenizer.rs
+++ b/cli/src/tokenizer.rs
@@ -31,7 +31,7 @@
 use core::fmt;
 use skytable::{types::RawString, Query};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum TokenizerError {
     QuoteMismatch(String),
 }
@@ -49,6 +49,7 @@ pub trait SequentialQuery {
     fn new() -> Self;
 }
 
+#[cfg(test)]
 impl SequentialQuery for Vec<String> {
     fn push(&mut self, input: &[u8]) {
         Vec::push(self, String::from_utf8_lossy(input).to_string())

--- a/cli/src/tokenizer.rs
+++ b/cli/src/tokenizer.rs
@@ -1,0 +1,143 @@
+/*
+ * Created on Sat Oct 09 2021
+ *
+ * This file is a part of Skytable
+ * Skytable (formerly known as TerrabaseDB or Skybase) is a free and open-source
+ * NoSQL database written by Sayan Nandan ("the Author") with the
+ * vision to provide flexibility in data modelling without compromising
+ * on performance, queryability or scalability.
+ *
+ * Copyright (c) 2021, Sayan Nandan <ohsayan@outlook.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+*/
+
+//! This module provides a simple way to avoid "the funk" with "funky input queries". It simply
+//! tokenizes char-by-char analyzing quotes et al as required
+//!
+
+use core::fmt;
+use skytable::{types::RawString, Query};
+
+#[derive(Debug)]
+pub enum TokenizerError {
+    QuoteMismatch(String),
+    BadExpression(String),
+}
+
+impl fmt::Display for TokenizerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::QuoteMismatch(expr) => write!(f, "mismatched quotes near end of: `{}`", expr),
+            Self::BadExpression(expr) => write!(f, "bad expression near end of: `{}`", expr),
+        }
+    }
+}
+
+pub trait SequentialQuery {
+    fn push(&mut self, input: &[u8]);
+    fn new() -> Self;
+}
+
+#[cfg(test)]
+impl SequentialQuery for Vec<String> {
+    fn push(&mut self, input: &[u8]) {
+        Vec::push(self, String::from_utf8_lossy(input).to_string())
+    }
+    fn new() -> Self {
+        Vec::new()
+    }
+}
+
+impl SequentialQuery for Query {
+    fn push(&mut self, input: &[u8]) {
+        Query::push(self, RawString::from(input.to_owned()))
+    }
+    fn new() -> Self {
+        Query::new()
+    }
+}
+
+pub fn get_query<T: SequentialQuery>(inp: &[u8]) -> Result<T, TokenizerError> {
+    if inp.is_empty() {
+        panic!("Input is empty");
+    }
+    let mut query = T::new();
+    let mut it = inp.iter().peekable();
+    macro_rules! pos {
+        () => {
+            inp.len() - it.len()
+        };
+    }
+    while let Some(tok) = it.next() {
+        match tok {
+            // numbers? nope
+            b'0'..=b'9' => {
+                return Err(TokenizerError::BadExpression(
+                    String::from_utf8_lossy(&inp[..pos!()]).to_string(),
+                ));
+            }
+            b'\'' => {
+                // hmm, quotes; let's see where it ends
+                let pos = pos!();
+                let qidx = it.position(|x| *x == b'\'');
+                match qidx {
+                    Some(idx) => query.push(&inp[pos..idx + pos]),
+                    None => {
+                        let end = pos!();
+                        return Err(TokenizerError::QuoteMismatch(
+                            String::from_utf8_lossy(&inp[pos..end]).to_string(),
+                        ));
+                    }
+                }
+            }
+            b'"' => {
+                // hmm, quotes; let's see where it ends
+                let pos = pos!();
+                let qidx = it.position(|x| *x == b'"');
+                match qidx {
+                    Some(idx) => query.push(&inp[pos..idx + pos]),
+                    None => {
+                        let end = pos!();
+                        return Err(TokenizerError::QuoteMismatch(
+                            String::from_utf8_lossy(&inp[pos..end]).to_string(),
+                        ));
+                    }
+                }
+            }
+            b' ' => {
+                // this just prevents control from being handed to the wildcard
+                continue;
+            }
+            _ => {
+                let start = pos!() - 1;
+                let mut end = start;
+                // alpha? cool, go on
+                while let Some(tok) = it.peek() {
+                    if **tok == b' ' {
+                        it.next();
+                        break;
+                    } else {
+                        end += 1;
+                        it.next();
+                    }
+                }
+                end += 1;
+                query.push(&inp[start..end]);
+            }
+        }
+    }
+    Ok(query)
+}

--- a/libsky/Cargo.toml
+++ b/libsky/Cargo.toml
@@ -1,17 +1,11 @@
 [package]
-name = "libsky"
-version = "0.7.1"
 authors = ["Sayan Nandan <ohsayan@outlook.com>"]
 edition = "2018"
+name = "libsky"
+version = "0.7.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# internal deps
-skytable = { git = "https://github.com/skytable/client-rust", branch = "next", features = [
-    "dbg",
-], default-features = false }
 # external deps
-lazy_static = "1.4.0"
 termcolor = "1.1.2"
-regex = "1.5.4"

--- a/libsky/src/lib.rs
+++ b/libsky/src/lib.rs
@@ -32,7 +32,6 @@
 //! This contains modules which are shared by both the `cli` and the `server` modules
 
 pub mod util;
-use skytable::Query;
 use std::error::Error;
 /// A generic result
 pub type TResult<T> = Result<T, Box<dyn Error>>;
@@ -42,12 +41,6 @@ pub const BUF_CAP: usize = 8 * 1024; // 8 KB per-connection
 pub static VERSION: &str = env!("CARGO_PKG_VERSION");
 /// The URL
 pub static URL: &str = "https://github.com/skytable/skytable";
-
-use std::str::FromStr;
-
-lazy_static::lazy_static! {
-    static ref RE: regex::Regex = regex::Regex::from_str(r#"("[^"]*"|'[^']*'|[\S]+)+"#).unwrap();
-}
 
 #[macro_export]
 /// Don't use unwrap_or but use this macro as the optimizer fails to optimize away usages
@@ -60,41 +53,4 @@ macro_rules! option_unwrap_or {
             None => $fallback,
         }
     };
-}
-
-pub fn split_into_args(q: &str) -> Vec<String> {
-    let args: Vec<String> = RE
-        .find_iter(q)
-        .map(|val| {
-            let mut v = val.as_str();
-            let mut chars = v.chars();
-            let first = chars.next();
-            let last = chars.last();
-            if let Some('"') = first {
-                v = &v[1..];
-                if let Some('"') = last {
-                    v = &v[..v.len()];
-                }
-            } else if let Some('\'') = first {
-                v = &v[1..];
-                if let Some('\'') = last {
-                    v = &v[..v.len()];
-                }
-            }
-            v.to_owned()
-        })
-        .collect();
-    args
-}
-
-pub fn turn_into_query(q: &str) -> Query {
-    let mut query = Query::new();
-    split_into_args(q).into_iter().for_each(|arg| {
-        query.push(arg);
-    });
-    query
-}
-
-pub fn into_raw_query(q: &str) -> Vec<u8> {
-    turn_into_query(q).into_raw_query()
 }


### PR DESCRIPTION
The Skytable shell (`skysh`) now:
- Reliably reads inputs with special characters
- Ignores extra whitespace between commands, for example: `set  x  100` will be treated just like `set x 100`
- Has more helpful error messages for incomplete expressions instead of silently ignoring them (often causing errors because a misquoted part was treated as an entirely different argument)
- Supports splitting commands across multiple lines:
  ```sh
  skysh> set myvery \
         verylongkey \
          myvalue
  ```
  (note the whitespace; adding a ` \` simply continues the line onto the next and adds no whitespace, as expected)