### PR TITLE
Add `range` to `lget`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ snapstore.partmap
 .sky_pid
 .devcontainer
 *.deb
+*.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All changes in this project will be noted in this file.
 
 ## Unreleased
 
+### Additions
+
+- Added `dev/prod` mode for making sure that the recommended production settings are used
+- Added support for system native endian storage (backward compatible)
+- Added `range` to `lget` to get subarrays
+
 ### Fixes
 
 - Fixed infinite wait (loop) when sample space for key generation is not large enough
@@ -11,11 +17,6 @@ All changes in this project will be noted in this file.
   parameters
 - Restored ability to use `--restore <backupdir>` to restore data from previous snapshots which was silently
   ignored
-
-### Additions
-
-- Added `dev/prod` mode for making sure that the recommended production settings are used
-- Added support for system native endian storage (backward compatible)
 
 ## Version 0.7.2
 

--- a/actiondoc.yml
+++ b/actiondoc.yml
@@ -221,7 +221,7 @@ keyvalue:
           accept: [AnyArray]
           syntax: [LGET <list> valueat <index>]
           desc: Returns the element present at the provided `index`, if it exists in the given list.
-          return: [String, binstr, Rcode 1, list-bad-index]
+          return: [String, binstr, Rcode 1, bad-list-index]
         - name: first
           complexity: O(1)
           accept: [AnyArray]
@@ -234,6 +234,14 @@ keyvalue:
           syntax: [LGET <list> last]
           desc: Returns the last element present in the list, if it exists.
           return: [String, binstr, Rcode 1, list-is-empty]
+        - name: range
+          complexity: O(n)
+          accept: [AnyArray]
+          syntax: [LGET <list> range <start>, LGET <list> range <start> <stop>]
+          desc: |
+            Returns items in the given range. If no value for `stop` is provided, all the elements from that
+            index are returned. If a value for `stop` is provided, then a subarray is returned
+          return: [Typed Array, Rcode 1, bad-list-index]
     - name: LMOD
       desc: |
         `LMOD` can be used to mutate the elements in a list

--- a/server/src/actions/lists/lget.rs
+++ b/server/src/actions/lists/lget.rs
@@ -196,7 +196,7 @@ action! {
                                     None => conwrite!(con, groups::NIL)?,
                                 }
                             }
-                            None => conwrite!(con, groups::ACTION_ERR)?,
+                            None => aerr!(con),
                         }
                     }
                     _ => conwrite!(con, groups::UNKNOWN_ACTION)?,

--- a/server/src/actions/lists/lget.rs
+++ b/server/src/actions/lists/lget.rs
@@ -35,6 +35,27 @@ const LIMIT: &[u8] = "LIMIT".as_bytes();
 const VALUEAT: &[u8] = "VALUEAT".as_bytes();
 const LAST: &[u8] = "LAST".as_bytes();
 const FIRST: &[u8] = "FIRST".as_bytes();
+const RANGE: &[u8] = "RANGE".as_bytes();
+
+struct Range {
+    start: usize,
+    stop: Option<usize>,
+}
+
+impl Range {
+    pub fn new(start: usize) -> Self {
+        Self { start, stop: None }
+    }
+    pub fn set_stop(&mut self, stop: usize) {
+        self.stop = Some(stop);
+    }
+    pub fn into_vec(self, slice: &[Data]) -> Option<Vec<Data>> {
+        match slice.get(self.start..self.stop.unwrap_or(slice.len())) {
+            Some(slc) => Some(slc.iter().cloned().collect()),
+            None => None,
+        }
+    }
+}
 
 action! {
     /// Handle an `LGET` query for the list model (KVExt)
@@ -145,6 +166,37 @@ action! {
                             },
                             Some(None) => conwrite!(con, groups::LISTMAP_LIST_IS_EMPTY)?,
                             None => conwrite!(con, groups::NIL)?,
+                        }
+                    }
+                    RANGE => {
+                        match act.next_string_owned() {
+                            Some(start) => {
+                                let start: usize = match start.parse() {
+                                    Ok(v) => v,
+                                    Err(_) => return conwrite!(con, groups::WRONGTYPE_ERR),
+                                };
+                                let mut range = Range::new(start);
+                                if let Some(stop) = act.next_string_owned() {
+                                    let stop: usize = match stop.parse() {
+                                        Ok(v) => v,
+                                        Err(_) => return conwrite!(con, groups::WRONGTYPE_ERR),
+                                    };
+                                    range.set_stop(stop);
+                                };
+                                match listmap.get(listname) {
+                                    Some(list) => {
+                                        let ret = range.into_vec(&list.read());
+                                        match ret {
+                                            Some(ret) => {
+                                                writelist!(con, listmap, ret);
+                                            },
+                                            None => conwrite!(con, groups::LISTMAP_BAD_INDEX)?,
+                                        }
+                                    }
+                                    None => conwrite!(con, groups::NIL)?,
+                                }
+                            }
+                            None => conwrite!(con, groups::ACTION_ERR)?,
                         }
                     }
                     _ => conwrite!(con, groups::UNKNOWN_ACTION)?,

--- a/server/src/actions/macros.rs
+++ b/server/src/actions/macros.rs
@@ -137,7 +137,7 @@ macro_rules! conwrite {
 
 #[macro_export]
 macro_rules! aerr {
-    ($con:expr, aerr) => {
+    ($con:expr) => {
         return conwrite!($con, crate::protocol::responses::groups::ACTION_ERR)
     };
 }

--- a/server/src/protocol/iter.rs
+++ b/server/src/protocol/iter.rs
@@ -109,6 +109,12 @@ impl<'a> AnyArrayIter<'a> {
     pub unsafe fn next_unchecked_bytes(&mut self) -> Bytes {
         Bytes::copy_from_slice(self.next_unchecked())
     }
+    pub fn map_next<T>(&mut self, cls: fn(&[u8]) -> T) -> Option<T> {
+        self.next().map(|v| cls(v))
+    }
+    pub fn next_string_owned(&mut self) -> Option<String> {
+        self.map_next(|v| String::from_utf8_lossy(&v).to_string())
+    }
 }
 
 impl<'a> Iterator for AnyArrayIter<'a> {

--- a/server/src/queryengine/inspect.rs
+++ b/server/src/queryengine/inspect.rs
@@ -62,7 +62,7 @@ action! {
                     _ => conwrite!(con, responses::groups::UNKNOWN_INSPECT_QUERY)?,
                 }
             }
-            None => aerr!(con, aerr),
+            None => aerr!(con),
         }
         Ok(())
     }
@@ -89,7 +89,7 @@ action! {
                     writer.write_element(tbl).await?;
                 }
             },
-            None => aerr!(con, aerr),
+            None => aerr!(con),
         }
         Ok(())
     }
@@ -102,7 +102,7 @@ action! {
                 let entity = handle_entity!(con, entity);
                 conwrite!(con, get_tbl!(entity, handle, con).describe_self())?;
             },
-            None => aerr!(con, aerr),
+            None => aerr!(con),
         }
         Ok(())
     }

--- a/server/src/tests/kvengine_list.rs
+++ b/server/src/tests/kvengine_list.rs
@@ -360,6 +360,59 @@ mod __private {
         runeq!(con, q, Element::UnsignedInt(2));
     }
 
+    // tests for range
+    async fn test_list_range_nil() {
+        let q = query!("lget", "sayan", "range", "1", "10");
+        runeq!(con, q, Element::RespCode(RespCode::NotFound));
+        let q = query!("lget", "sayan", "range", "1");
+        runeq!(con, q, Element::RespCode(RespCode::NotFound));
+    }
+
+    async fn test_list_range_bounded_okay() {
+        lset!(con, "mylist", "1", "2", "3", "4", "5");
+        let q = query!("lget", "mylist", "range", "0", "5");
+        assert_skyhash_arrayeq!(str, con, q, "1", "2", "3", "4", "5");
+    }
+
+    async fn test_list_range_bounded_fail() {
+        lset!(con, "mylist", "1", "2", "3", "4", "5");
+        let q = query!("lget", "mylist", "range", "0", "165");
+        runeq!(
+            con,
+            q,
+            Element::RespCode(RespCode::ErrorString("listmap-bad-index".to_owned()))
+        )
+    }
+
+    async fn test_list_range_unbounded_okay() {
+        lset!(con, "mylist", "1", "2", "3", "4", "5");
+        let q = query!("lget", "mylist", "range", "0");
+        assert_skyhash_arrayeq!(str, con, q, "1", "2", "3", "4", "5");
+    }
+
+    async fn test_list_range_unbounded_fail() {
+        lset!(con, "mylist", "1", "2", "3", "4", "5");
+        let q = query!("lget", "mylist", "range", "165");
+        runeq!(
+            con,
+            q,
+            Element::RespCode(RespCode::ErrorString("listmap-bad-index".to_owned()))
+        )
+    }
+
+    async fn test_list_range_parse_fail() {
+        let q = query!("lget", "mylist", "1", "2a");
+        runeq!(con, q, Element::RespCode(RespCode::Wrongtype));
+        let q = query!("lget", "mylist", "2a");
+        runeq!(con, q, Element::RespCode(RespCode::Wrongtype));
+        // now do the same with an existing key
+        lset!(con, "mylist", "a", "b", "c");
+        let q = query!("lget", "mylist", "1", "2a");
+        runeq!(con, q, Element::RespCode(RespCode::Wrongtype));
+        let q = query!("lget", "mylist", "2a");
+        runeq!(con, q, Element::RespCode(RespCode::Wrongtype));
+    }
+
     // sanity tests
     async fn test_get_model_error() {
         query.push("GET");

--- a/server/src/tests/kvengine_list.rs
+++ b/server/src/tests/kvengine_list.rs
@@ -380,7 +380,7 @@ mod __private {
         runeq!(
             con,
             q,
-            Element::RespCode(RespCode::ErrorString("listmap-bad-index".to_owned()))
+            Element::RespCode(RespCode::ErrorString("bad-list-index".to_owned()))
         )
     }
 
@@ -396,20 +396,20 @@ mod __private {
         runeq!(
             con,
             q,
-            Element::RespCode(RespCode::ErrorString("listmap-bad-index".to_owned()))
+            Element::RespCode(RespCode::ErrorString("bad-list-index".to_owned()))
         )
     }
 
     async fn test_list_range_parse_fail() {
-        let q = query!("lget", "mylist", "1", "2a");
+        let q = query!("lget", "mylist", "range", "1", "2a");
         runeq!(con, q, Element::RespCode(RespCode::Wrongtype));
-        let q = query!("lget", "mylist", "2a");
+        let q = query!("lget", "mylist", "range", "2a");
         runeq!(con, q, Element::RespCode(RespCode::Wrongtype));
         // now do the same with an existing key
         lset!(con, "mylist", "a", "b", "c");
-        let q = query!("lget", "mylist", "1", "2a");
+        let q = query!("lget", "mylist", "range", "1", "2a");
         runeq!(con, q, Element::RespCode(RespCode::Wrongtype));
-        let q = query!("lget", "mylist", "2a");
+        let q = query!("lget", "mylist", "range", "2a");
         runeq!(con, q, Element::RespCode(RespCode::Wrongtype));
     }
 


### PR DESCRIPTION
This adds a `range` subcommand to `lget`, enabling slicing of lists.