### PR TITLE
Stronger systemd confinement

### DIFF
--- a/pkg/common/skyd.service
+++ b/pkg/common/skyd.service
@@ -9,7 +9,37 @@ Restart=always
 RestartSec=1
 User=skytable
 ExecStart=/usr/bin/skyd --noart
+StandardError=journal
 WorkingDirectory=/var/lib/skytable
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+#ProtectSystem=strict
+ProtectHome=yes
+CapabilityBoundingSet=
+RestrictNamespaces=true
+
+PrivateDevices=true
+DevicePolicy=strict
+DeviceAllow=/dev/null rw
+DeviceAllow=/dev/random r
+DeviceAllow=/dev/urandom r
+
+PrivateUsers=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+SystemCallArchitectures=native
+LockPersonality=true
+RestrictSUIDSGID=true
+RemoveIPC=true
+MemoryDenyWriteExecute=true
+# Can be further constrained
+SystemCallFilter=@system-service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
systemd provides us with mechanisms to use its power over `cgroupv2` and `seccomp` to limit units to only those resources they need for their work. This works like a container sandbox.

The config provided here is quite permissive, since we can `strace` out all the necessary syscalls and allow only those, but that is way too strict for an inherently secure Rust program. I guess this config is rather balanced between security and maintainability (it's hard to cause breakages with it when new features are added).

Tested on my Debian 11 server (slightly modified to use a free port there) 