### PR TITLE
add skysh to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@
 FROM debian:stable
 
 COPY target/release/skyd /usr/local/bin
+COPY target/release/skysh /usr/local/bin
 RUN mkdir /etc/skytable
 RUN mkdir /var/lib/skytable
 COPY examples/config-files/docker.toml /etc/skytable/skyd.toml


### PR DESCRIPTION
Hey there, would be nice to have the CLI Tool `skysh` inside the Docker image for readinessProbe in Kubernetes.