### PR TITLE
net: Fix RST and thread crash due to multiple HS errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All changes in this project will be noted in this file.
 - Skyhash/2: Restored support for pipelines
 - Enable online (runtime) recovery of transactional failures due to disk errors
 
+### Fixes
+
+- Fixed an issue where an incorrect handshake with multiple errors cause the client connection
+  to be terminated without yielding an error
+
 ## Version 0.8.1
 
 ### Additions


### PR DESCRIPTION
Fixes a misc. crash during connection stage due to multiple errors within the same packet. This was overlooked. This however doesn't pose any serious issue as the connection would've anyways been terminated (just that we don't yield a correct error) and the rt catches the panic.