### PR TITLE
BQL,QE,SE: Add UPSERT query, BQL query shorthands and fix SE bootup crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All changes in this project will be noted in this file.
 - Fixed SE bug that resulted in unsafe cleanup of journals when multiple failures occur in sequence
 - Fixed SE memory management bug in delta diff algorithm: In rare cases, a crash might occur on startup (*only during startup* and *not* at runtime)
 
+### Platform notes
+
+- 32-bit Windows (MSVC) has been downgraded to a Tier-2 platform and will likely be deprecated in the future
+
 ## Version 0.8.1
 
 ### Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ All changes in this project will be noted in this file.
 
 ### Fixes
 
-- Fixed an issue where an incorrect handshake with multiple errors cause the client connection
+- Fixed an issue where an incorrect handshake with multiple errors caused the client connection
   to be terminated without yielding an error
 - Fixed SE bug that resulted in unsafe cleanup of journals when multiple failures occur in sequence
+- Fixed SE memory management bug in delta diff algorithm: In rare cases, a crash might occur on startup (*only during startup* and *not* at runtime)
 
 ## Version 0.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,18 @@ All changes in this project will be noted in this file.
 
 - Skyhash/2: Restored support for pipelines
 - Enable online (runtime) recovery of transactional failures due to disk errors
+- Added BlueQL shorthands:
+  - `INSERT`: `INS`
+  - `SELECT`: `SEL`
+  - `UPDATE`: `UPD`
+  - `DELETE`: `DEL`
+- Added new `UPSERT` (shorthand: `UPS`) query
 
 ### Fixes
 
 - Fixed an issue where an incorrect handshake with multiple errors cause the client connection
   to be terminated without yielding an error
+- Fixed SE bug that resulted in unsafe cleanup of journals when multiple failures occur in sequence
 
 ## Version 0.8.1
 

--- a/harness/src/test/mod.rs
+++ b/harness/src/test/mod.rs
@@ -114,7 +114,8 @@ fn run_test_inner() -> HarnessResult<()> {
     append_target(&mut standard_test_suite_args);
     // get cmd
     let build_cmd = util::assemble_command_from_slice(build_cmd_args);
-    let standard_test_suite = util::assemble_command_from_slice(standard_test_suite_args);
+    let mut standard_test_suite = util::assemble_command_from_slice(standard_test_suite_args);
+    standard_test_suite.env("RUST_MIN_STACK", "16777216");
 
     // build skyd
     info!("Building server binary ...");

--- a/server/src/engine/core/dml/ins.rs
+++ b/server/src/engine/core/dml/ins.rs
@@ -49,7 +49,7 @@ pub fn insert_resp(
 pub fn insert(global: &impl GlobalInstanceLike, insert: InsertStatement) -> QueryResult<()> {
     core::with_model_for_data_update(global, insert.entity(), |mdl| {
         let (pk, data) = prepare_insert(mdl, insert.data())?;
-        let _idx_latch = mdl.primary_index().acquire_cd();
+        let _idx_latch = mdl.primary_index().acquire_shared();
         let g = cpin();
         let ds = mdl.delta_state();
         // create new version
@@ -69,7 +69,7 @@ pub fn upsert(global: &impl GlobalInstanceLike, insert: InsertStatement) -> Quer
     let mut ret = false;
     core::with_model_for_data_update(global, insert.entity(), |mdl| {
         let (pk, data) = prepare_insert(mdl, insert.data())?;
-        let _idx_latch = mdl.primary_index().acquire_cd();
+        let _idx_latch = mdl.primary_index().acquire_shared();
         let g = cpin();
         let ds = mdl.delta_state();
         // create new version

--- a/server/src/engine/core/dml/mod.rs
+++ b/server/src/engine/core/dml/mod.rs
@@ -48,7 +48,7 @@ pub use {
 };
 pub use {
     del::delete_resp,
-    ins::insert_resp,
+    ins::{insert_resp, upsert_resp},
     sel::{select_all_resp, select_resp},
     upd::update_resp,
 };

--- a/server/src/engine/core/exec.rs
+++ b/server/src/engine/core/exec.rs
@@ -269,7 +269,7 @@ fn run_nb(
         let n_offset_adjust = (stmt == KeywordStmt::Select) & state.cursor_rounded_eq(Token![all]);
         state.cursor_ahead_if(n_offset_adjust);
         let corrected_offset =
-            (n_offset_adjust as u8 * F.len() as u8) | (stmt_c * (!n_offset_adjust as u8));
+            (n_offset_adjust as u8 * (F.len() - 1) as u8) | (stmt_c * (!n_offset_adjust as u8));
         let mut state = unsafe {
             // UNSAFE(@ohsayan): this is a lifetime issue with the token handle
             core::mem::transmute(state)

--- a/server/src/engine/core/index/mod.rs
+++ b/server/src/engine/core/index/mod.rs
@@ -53,7 +53,7 @@ impl PrimaryIndex {
             latch: IndexLatch::new(),
         }
     }
-    pub fn acquire_cd(&self) -> IndexLatchHandleShared {
+    pub fn acquire_shared(&self) -> IndexLatchHandleShared {
         self.latch.gl_handle_shared()
     }
     pub fn acquire_exclusive(&self) -> IndexLatchHandleExclusive {

--- a/server/src/engine/core/index/row.rs
+++ b/server/src/engine/core/index/row.rs
@@ -56,6 +56,10 @@ pub struct RowData {
 }
 
 impl RowData {
+    #[cfg(test)]
+    pub fn get_schema_version(&self) -> DeltaVersion {
+        self.txn_revised_schema_version
+    }
     pub fn fields(&self) -> &DcFieldIndex {
         &self.fields
     }

--- a/server/src/engine/core/model/delta.rs
+++ b/server/src/engine/core/model/delta.rs
@@ -235,5 +235,9 @@ pub enum DataDeltaKind {
     Delete = 0,
     Insert = 1,
     Update = 2,
-    Upsert = 3,
+    /*
+        HACK(@ohsayan): I was daft enough to map (hardcode) an `EarlyExit` event (skewed read) to OPC 3 in the SE.
+        Hence, we have no choice but to map this to 4
+    */
+    Upsert = 4,
 }

--- a/server/src/engine/core/model/delta.rs
+++ b/server/src/engine/core/model/delta.rs
@@ -235,4 +235,5 @@ pub enum DataDeltaKind {
     Delete = 0,
     Insert = 1,
     Update = 2,
+    Upsert = 3,
 }

--- a/server/src/engine/core/model/mod.rs
+++ b/server/src/engine/core/model/mod.rs
@@ -468,6 +468,10 @@ pub struct ModelMutator<'a> {
 }
 
 impl<'a> ModelMutator<'a> {
+    #[cfg(test)]
+    pub unsafe fn allocate(&mut self, k: &str) -> RawStr {
+        self.model.private.allocate_or_recycle(k)
+    }
     pub unsafe fn vacuum_stashed(&mut self) {
         self.model.private.vacuum_marked()
     }

--- a/server/src/engine/idx/mod.rs
+++ b/server/src/engine/idx/mod.rs
@@ -166,7 +166,7 @@ pub trait MTIndex<E, K, V>: IndexBaseSpec {
     where
         V: AsValue;
     /// Updates or inserts the given value
-    fn mt_upsert(&self, e: E, g: &Guard)
+    fn mt_upsert(&self, e: E, g: &Guard) -> bool
     where
         V: AsValue;
     // read

--- a/server/src/engine/idx/mtchm/imp.rs
+++ b/server/src/engine/idx/mtchm/imp.rs
@@ -128,7 +128,7 @@ impl<E: TreeElement, C: Config> MTIndex<E, E::Key, E::Value> for Raw<E, C> {
         self.patch(VanillaInsert(e), g)
     }
 
-    fn mt_upsert(&self, e: E, g: &Guard)
+    fn mt_upsert(&self, e: E, g: &Guard) -> bool
     where
         E::Value: AsValue,
     {

--- a/server/src/engine/idx/mtchm/patch.rs
+++ b/server/src/engine/idx/mtchm/patch.rs
@@ -85,7 +85,7 @@ impl<T: TreeElement> PatchWrite<T> for VanillaInsert<T> {
 pub struct VanillaUpsert<T: TreeElement>(pub T);
 impl<T: TreeElement> PatchWrite<T> for VanillaUpsert<T> {
     const WMODE: WriteFlag = WRITEMODE_ANY;
-    type Ret<'a> = ();
+    type Ret<'a> = bool;
     type Target = T::Key;
     fn target<'a>(&'a self) -> &Self::Target {
         self.0.key()
@@ -94,12 +94,16 @@ impl<T: TreeElement> PatchWrite<T> for VanillaUpsert<T> {
     fn nx_new(&mut self) -> T {
         self.0.clone()
     }
-    fn nx_ret<'a>() -> Self::Ret<'a> {}
+    fn nx_ret<'a>() -> Self::Ret<'a> {
+        false
+    }
     // ex
     fn ex_apply(&mut self, _: &T) -> T {
         self.0.clone()
     }
-    fn ex_ret<'a>(_: &'a T) -> Self::Ret<'a> {}
+    fn ex_ret<'a>(_: &'a T) -> Self::Ret<'a> {
+        true
+    }
 }
 
 pub struct VanillaUpsertRet<T: TreeElement>(pub T);

--- a/server/src/engine/ql/tests.rs
+++ b/server/src/engine/ql/tests.rs
@@ -33,7 +33,7 @@ use {
         engine::{data::cell::Datacell, error::QueryResult},
         util::test_utils,
     },
-    rand::{self, Rng},
+    rand::Rng,
 };
 
 mod dcl;

--- a/server/src/engine/ql/tests/misc.rs
+++ b/server/src/engine/ql/tests/misc.rs
@@ -26,7 +26,7 @@
 
 use super::*;
 use crate::engine::ql::{
-    ast::{traits::ASTNode, State},
+    ast::State,
     ddl::{Inspect, Use},
 };
 

--- a/server/src/engine/ql/tests/schema_tests.rs
+++ b/server/src/engine/ql/tests/schema_tests.rs
@@ -30,10 +30,7 @@ use {
 };
 
 mod alter_space {
-    use {
-        super::*,
-        crate::engine::{data::lit::Lit, ql::ddl::alt::AlterSpace},
-    };
+    use {super::*, crate::engine::ql::ddl::alt::AlterSpace};
     #[test]
     fn alter_space_mini() {
         fullparse_verify_substmt("alter model mymodel with {}", |r: AlterSpace| {
@@ -66,7 +63,7 @@ mod alter_space {
 mod tymeta {
     use super::*;
     use crate::engine::ql::{
-        ast::{parse_ast_node_full, traits::ASTNode, State},
+        ast::{parse_ast_node_full, State},
         ddl::syn::{DictTypeMeta, DictTypeMetaSplit},
     };
     #[test]
@@ -271,7 +268,6 @@ mod fields {
         crate::engine::ql::{
             ast::parse_ast_node_full,
             ddl::syn::{FieldSpec, LayerSpec},
-            lex::Ident,
         },
     };
     #[test]
@@ -716,7 +712,6 @@ mod alter_model_remove {
     use crate::engine::ql::{
         ast::parse_ast_node_full_with_space,
         ddl::alt::{AlterKind, AlterModel},
-        lex::Ident,
     };
     #[test]
     fn alter_mini() {
@@ -1095,7 +1090,6 @@ mod ddl_other_query_tests {
         crate::engine::ql::{
             ast::{parse_ast_node_full, parse_ast_node_full_with_space},
             ddl::drop::{DropModel, DropSpace},
-            lex::Ident,
         },
     };
     #[test]

--- a/server/src/engine/storage/v2/impls/mdl_journal.rs
+++ b/server/src/engine/storage/v2/impls/mdl_journal.rs
@@ -143,12 +143,13 @@ impl<'b> RowWriter<'b> {
         change: DataDeltaKind,
         txn_id: DeltaVersion,
     ) -> RuntimeResult<()> {
-        if cfg!(debug) {
+        if cfg!(debug_assertions) {
             let event_kind = EventType::try_from_raw(change.value_u8()).unwrap();
             match (event_kind, change) {
                 (EventType::Delete, DataDeltaKind::Delete)
                 | (EventType::Insert, DataDeltaKind::Insert)
-                | (EventType::Update, DataDeltaKind::Update) => {}
+                | (EventType::Update, DataDeltaKind::Update)
+                | (EventType::Upsert, DataDeltaKind::Upsert) => {}
                 (EventType::EarlyExit, _) => unreachable!(),
                 _ => panic!(),
             }
@@ -384,6 +385,7 @@ pub struct BatchMetadata {
     column_count: u64,
 }
 
+#[derive(Debug)]
 enum DecodedBatchEventKind {
     Delete,
     Insert(Vec<Datacell>),
@@ -396,6 +398,7 @@ pub struct BatchRestoreState {
     events: Vec<DecodedBatchEvent>,
 }
 
+#[derive(Debug)]
 struct DecodedBatchEvent {
     txn_id: DeltaVersion,
     pk: PrimaryIndexKey,

--- a/server/src/engine/storage/v2/impls/tests/model_driver/generic.rs
+++ b/server/src/engine/storage/v2/impls/tests/model_driver/generic.rs
@@ -283,6 +283,7 @@ fn model_data_inserts() {
 }
 
 #[test]
+#[cfg(not(all(target_os = "windows", target_pointer_width = "32")))]
 fn model_data_updates() {
     run_sample_updates(
         "model_data_updates_variable_key",

--- a/server/src/engine/storage/v2/impls/tests/model_driver/generic.rs
+++ b/server/src/engine/storage/v2/impls/tests/model_driver/generic.rs
@@ -1,5 +1,5 @@
 /*
- * Created on Thu Feb 22 2024
+ * Created on Mon Apr 15 2024
  *
  * This file is a part of Skytable
  * Skytable (formerly known as TerrabaseDB or Skybase) is a free and open-source

--- a/server/src/engine/storage/v2/impls/tests/model_driver/mod.rs
+++ b/server/src/engine/storage/v2/impls/tests/model_driver/mod.rs
@@ -1,0 +1,28 @@
+/*
+ * Created on Thu Feb 22 2024
+ *
+ * This file is a part of Skytable
+ * Skytable (formerly known as TerrabaseDB or Skybase) is a free and open-source
+ * NoSQL database written by Sayan Nandan ("the Author") with the
+ * vision to provide flexibility in data modelling without compromising
+ * on performance, queryability or scalability.
+ *
+ * Copyright (c) 2024, Sayan Nandan <nandansayan@outlook.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+*/
+
+mod generic;
+mod skew;

--- a/server/src/engine/storage/v2/impls/tests/model_driver/skew.rs
+++ b/server/src/engine/storage/v2/impls/tests/model_driver/skew.rs
@@ -1,0 +1,212 @@
+/*
+ * Created on Mon Apr 15 2024
+ *
+ * This file is a part of Skytable
+ * Skytable (formerly known as TerrabaseDB or Skybase) is a free and open-source
+ * NoSQL database written by Sayan Nandan ("the Author") with the
+ * vision to provide flexibility in data modelling without compromising
+ * on performance, queryability or scalability.
+ *
+ * Copyright (c) 2024, Sayan Nandan <nandansayan@outlook.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+*/
+
+/*
+    skew tests are vital for ensuring integrity
+*/
+
+use {
+    crate::{
+        engine::{
+            core::{
+                index::{PrimaryIndexKey, Row},
+                model::{
+                    delta::{DataDeltaKind, DeltaVersion},
+                    Field, Layer, Model, ModelData,
+                },
+            },
+            data::{
+                cell::Datacell,
+                tag::{DataTag, FullTag},
+                uuid::Uuid,
+            },
+            error::ErrorKind,
+            fractal::FractalModelDriver,
+            idx::{IndexBaseSpec, IndexSTSeqCns, MTIndex, STIndex},
+            mem::RawStr,
+            storage::{
+                common::interface::fs::FileSystem,
+                v2::{impls::mdl_journal::StdModelBatch, raw::journal::JournalSettings},
+                BatchStats, ModelDriver,
+            },
+        },
+        util::test_utils,
+    },
+    crossbeam_epoch::{pin, Guard},
+    rand::seq::SliceRandom,
+};
+
+fn initialize_or_reopen_model_driver(name: &str, mdl_uuid: Uuid) -> Model {
+    let mut mdl_fields = IndexSTSeqCns::idx_init();
+    mdl_fields.st_insert("password".into(), Field::new([Layer::str()].into(), false));
+
+    let mdl = Model::new(
+        ModelData::new_restore(mdl_uuid, "username".into(), FullTag::STR, mdl_fields),
+        FractalModelDriver::uninitialized(),
+    );
+    let mdl_driver = match ModelDriver::create_model_driver(name) {
+        Ok(m) => m,
+        Err(e) => match e.kind() {
+            ErrorKind::IoError(io) => match io.kind() {
+                std::io::ErrorKind::AlreadyExists => {
+                    ModelDriver::open_model_driver(mdl.data(), name, JournalSettings::default())
+                        .unwrap()
+                }
+                _ => panic!("{e}"),
+            },
+            _ => panic!("{e}"),
+        },
+    };
+    mdl.driver().initialize_model_driver(mdl_driver);
+    mdl
+}
+
+fn factorial(mut l: usize) -> usize {
+    let mut fctr = 1;
+    while l != 0 {
+        fctr *= l;
+        l -= 1;
+    }
+    fctr
+}
+
+fn npr(l: usize) -> usize {
+    factorial(l) / factorial(0)
+}
+
+fn npr_compensated(l: usize) -> usize {
+    const COMPENSATION_MULTIPLIER: usize = 2;
+    // compensate for low quality randomness
+    npr(l) * COMPENSATION_MULTIPLIER
+}
+
+#[test]
+fn skewed_insert_update_delete() {
+    let mut rng = test_utils::rng();
+    let make_row = |field_id_ptr: RawStr| {
+        Row::new(
+            PrimaryIndexKey::try_from_dc(Datacell::new_str("sayan".into()).into()).unwrap(),
+            into_dict!(field_id_ptr => Datacell::new_str("pwd1".into())),
+            DeltaVersion::genesis(),
+            DeltaVersion::genesis(),
+        )
+    };
+    decl! {
+        let orig_actions: [fn(&Model, &Row, &Guard)] = [
+            // insert (t=0)
+            |model, row, g| {
+                const VERSION: DeltaVersion = DeltaVersion::__new(0);
+                model.data().delta_state().append_new_data_delta_with(
+                    DataDeltaKind::Insert,
+                    row.clone(),
+                    VERSION,
+                    &g,
+                );
+            },
+            // update (t=1)
+            |model, row, g| {
+                const VERSION: DeltaVersion = DeltaVersion::__new(1);
+                let mut row_data = row.d_data().write();
+                if row_data.get_txn_revised() < VERSION {
+                    row_data.set_txn_revised(VERSION);
+                }
+                model.data().delta_state().append_new_data_delta_with(
+                    DataDeltaKind::Update,
+                    row.clone(),
+                    VERSION,
+                    &g,
+                );
+            },
+            // delete (t=2)
+            |model, row, g| {
+                const VERSION: DeltaVersion = DeltaVersion::__new(2);
+                let mut row_data = row.d_data().write();
+                if row_data.get_txn_revised() < VERSION {
+                    row_data.set_txn_revised(VERSION);
+                }
+                model.data().delta_state().append_new_data_delta_with(
+                    DataDeltaKind::Delete,
+                    row.clone(),
+                    VERSION,
+                    &g,
+                );
+            },
+        ];
+    }
+    test_utils::with_variable("skewed_insert_delete", |log_name| {
+        /*
+            iterate over all (hopefully) possible permutations of events
+        */
+        for _ in 0..npr_compensated(orig_actions.len()) {
+            let mut actions = orig_actions;
+            actions.shuffle(&mut rng);
+            /*
+                iterate over all possible batching sequences:
+                [1]:[1,2], [1, 2]:[3], [1, 2, 3]:[]
+            */
+            for batching_sequence in 1..=orig_actions.len() {
+                let batching_sequences =
+                    [batching_sequence, orig_actions.len() - batching_sequence];
+                /*
+                    now init model
+                */
+                let g = pin();
+                let mdl_uuid = Uuid::new();
+                let mut model = initialize_or_reopen_model_driver(log_name, mdl_uuid);
+                // create a row
+                let row =
+                    make_row(unsafe { model.data_mut().model_mutator().allocate("password") });
+                // apply events
+                for action in actions {
+                    (action)(&model, &row, &g);
+                }
+                // commit and close
+                {
+                    {
+                        let mut model_driver = model.driver().batch_driver().lock();
+                        let model_driver = model_driver.as_mut().unwrap();
+                        for observed_len in batching_sequences {
+                            model_driver
+                                .commit_with_ctx(
+                                    StdModelBatch::new(model.data(), observed_len),
+                                    BatchStats::new(),
+                                )
+                                .unwrap();
+                        }
+                        ModelDriver::close_driver(model_driver).unwrap();
+                    }
+                    drop(model);
+                }
+                // reopen
+                let mdl = initialize_or_reopen_model_driver(log_name, mdl_uuid);
+                assert_eq!(mdl.data().primary_index().__raw_index().mt_len(), 0);
+                // remove
+                drop(mdl);
+                FileSystem::remove_file(log_name).unwrap();
+            }
+        }
+    })
+}

--- a/server/src/util/macros.rs
+++ b/server/src/util/macros.rs
@@ -262,3 +262,11 @@ macro_rules! exit_fatal {
         $crate::util::exit_error()
     }};
 }
+
+#[cfg(test)]
+macro_rules! decl {
+    ($(let $array:ident: [$type:ty] = [$($expr:expr),* $(,)?]);* $(;)?) => {
+        $(mod $array { pub const SIZE: usize = { let mut i = 0; $(let _ = stringify!($expr); i += 1;)* i += 0; i }; }
+        let $array: [$type; $array::SIZE] = [$($expr),*];)*
+    }
+}

--- a/server/src/util/macros.rs
+++ b/server/src/util/macros.rs
@@ -263,7 +263,7 @@ macro_rules! exit_fatal {
     }};
 }
 
-#[cfg(test)]
+#[allow(unused_macros)]
 macro_rules! decl {
     ($(let $array:ident: [$type:ty] = [$($expr:expr),* $(,)?]);* $(;)?) => {
         $(mod $array { pub const SIZE: usize = { let mut i = 0; $(let _ = stringify!($expr); i += 1;)* i += 0; i }; }

--- a/server/src/util/test_utils.rs
+++ b/server/src/util/test_utils.rs
@@ -52,7 +52,7 @@ pub fn shuffle_slice<T>(slice: &mut [T], rng: &mut impl Rng) {
     slice.shuffle(rng)
 }
 
-pub fn with_variable<T, U>(variable: T, f: impl Fn(T) -> U) -> U {
+pub fn with_variable<T, U>(variable: T, mut f: impl FnMut(T) -> U) -> U {
     f(variable)
 }
 


### PR DESCRIPTION
- Add BlueQL shorthands for DML queries
- Added `UPSERT` (update or insert) query
- Fixed SE memory bug (only affects startup)
