### PR TITLE
CI: Fully resume building and testing ARM64 hosts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
           - rust: aarch64-unknown-linux-gnu
             os: [self-hosted, ARM64]
             artifact: arm64-linux-gnu
+          - rust: aarch64-apple-darwin
+            os: macos-14
+            artifact: arm64-macos
     env:
       RUST_BACKTRACE: 1
       TARGET: ${{ matrix.rust }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust:
-          [
-            x86_64-unknown-linux-gnu,
-            x86_64-unknown-linux-musl,
-            x86_64-apple-darwin,
-            x86_64-pc-windows-msvc,
-          ]
         include:
           - rust: x86_64-unknown-linux-gnu
             os: ubuntu-latest
@@ -35,6 +28,9 @@ jobs:
           - rust: x86_64-pc-windows-msvc
             os: windows-latest
             artifact: x86_64-windows
+          - rust: aarch64-unknown-linux-gnu
+            os: [self-hosted, ARM64]
+            artifact: arm64-linux-gnu
     env:
       RUST_BACKTRACE: 1
       TARGET: ${{ matrix.rust }}

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -48,6 +48,8 @@ jobs:
             rust: x86_64-apple-darwin
           - os: windows-latest
             rust: x86_64-pc-windows-msvc
+          - os: [self-hosted, ARM64]
+            rust: aarch64-unknown-linux-gnu
 
     steps:
       - name: Checkout source code

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -40,7 +40,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
             rust: x86_64-unknown-linux-gnu
@@ -50,6 +49,8 @@ jobs:
             rust: x86_64-pc-windows-msvc
           - os: [self-hosted, ARM64]
             rust: aarch64-unknown-linux-gnu
+          - os: macos-14
+            rust: aarch64-apple-darwin
 
     steps:
       - name: Checkout source code
@@ -92,7 +93,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
         include:
           - os: ubuntu-latest
             rust: i686-unknown-linux-gnu
@@ -133,7 +133,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
         include:
           - os: ubuntu-latest
             rust: x86_64-unknown-linux-musl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All changes in this project will be noted in this file.
 ### Platform notes
 
 - 32-bit Windows (MSVC) has been downgraded to a Tier-2 platform and will likely be deprecated in the future
+- Linux ARM64 is now a Tier-1 platform
+- macOS ARM64 is a now a Tier-1X platform
 
 ## Version 0.8.1
 

--- a/harness/src/diagnostics.rs
+++ b/harness/src/diagnostics.rs
@@ -26,11 +26,13 @@
 
 use crate::util;
 
-const OFFICIAL_TARGETS: [&str; 4] = [
-    "i686-unknown-linux-gnu",
-    "x86_64-apple-darwin",
-    "x86_64-pc-windows-msvc",
-    "x86_64-unknown-linux-gnu",
+const OFFICIAL_TARGETS: [&str; 6] = [
+    "i686-unknown-linux-gnu",    // GNU Linux x86
+    "x86_64-apple-darwin",       // macOS x86_64
+    "x86_64-pc-windows-msvc",    // Windows x86_64
+    "x86_64-unknown-linux-gnu",  // Linux x86_64
+    "aarch64-unknown-linux-gnu", // Linux ARM64
+    "aarch64-apple-darwin",      // macOS ARM64
 ];
 
 const THIS_TARGET: &str = env!("RUSTC_TARGET");


### PR DESCRIPTION
This PR fully resumes building on all Tier-1(X) ARM64 platforms including Linux ARM64 (GNU; with full support) and macOS ARM64 (with full support, pending toolchain upgrade).

We're currently paying for the Linux ARM64 builds out of pocket, but once GitHub opens up Linux ARM64 runners we will migrate to it.

fixes #298, fixes #310 and closes #335 