### PR TITLE
storage: Add support for compaction and fix DCL bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All changes in this project will be noted in this file.
     - `UPDATE`: `UPD`
     - `DELETE`: `DEL`
   - Added new `UPSERT` (shorthand: `UPS`) query
+  - Auto-compaction of journal(s) on boot
 - CLI:
   - Enable setting custom history file location using the `SKYSH_HISTORY_FILE` environment variable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All changes in this project will be noted in this file.
     to be terminated without yielding an error
   - Fixed SE bug that resulted in unsafe cleanup of journals when multiple failures occur in sequence
   - Fixed SE memory management bug in delta diff algorithm: In rare cases, a crash might occur on startup (*only during startup* and *not* at runtime)
+  - Fixed DCL command `sysctl alter user` not working properly (preventing change of any data)
 - CLI:
   - Fixed transient history file location. History is now always saved to $HOME/.sky_history
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All changes in this project will be noted in this file.
     - `DELETE`: `DEL`
   - Added new `UPSERT` (shorthand: `UPS`) query
   - Auto-compaction of journal(s) on boot
+  - Allow manual compaction with `skyd compact` subcommand
 - CLI:
   - Enable setting custom history file location using the `SKYSH_HISTORY_FILE` environment variable
 

--- a/server/help_text/help
+++ b/server/help_text/help
@@ -15,6 +15,7 @@ skyd is the Skytable database server daemon and can be used to serve database re
 
 Commands:
   repair                        Check and repair any detected database storage errors
+  compact                       Force optimize all database files
 
 Flags:
   -h, --help                    Display this help menu and exit.

--- a/server/src/engine/core/mod.rs
+++ b/server/src/engine/core/mod.rs
@@ -81,6 +81,10 @@ impl GlobalNS {
     pub fn gns_driver(&self) -> &FractalGNSDriver {
         &self.driver
     }
+    #[cfg(test)]
+    pub fn into_inner(self) -> (GNSData, FractalGNSDriver) {
+        (self.data, self.driver)
+    }
 }
 
 #[derive(Debug)]

--- a/server/src/engine/core/model/delta.rs
+++ b/server/src/engine/core/model/delta.rs
@@ -121,6 +121,10 @@ impl DeltaState {
     pub fn schema_current_version(&self) -> DeltaVersion {
         DeltaVersion(self.schema_current_version)
     }
+    #[cfg(test)]
+    pub fn data_current_version(&self) -> DeltaVersion {
+        DeltaVersion(self.data_current_version.load(Ordering::Acquire))
+    }
     pub fn unresolved_append_field_add(&mut self, field_name: RawStr) {
         self.__schema_append_unresolved_delta(SchemaDeltaPart::field_add(field_name));
     }

--- a/server/src/engine/core/util.rs
+++ b/server/src/engine/core/util.rs
@@ -36,6 +36,11 @@ pub struct EntityID {
     el: usize,
 }
 
+#[cfg(test)]
+unsafe impl Send for EntityID {}
+#[cfg(test)]
+unsafe impl Sync for EntityID {}
+
 impl EntityID {
     pub fn new(space: &str, entity: &str) -> Self {
         let mut space = ManuallyDrop::new(space.to_owned().into_boxed_str().into_boxed_bytes());

--- a/server/src/engine/fractal/test_utils.rs
+++ b/server/src/engine/fractal/test_utils.rs
@@ -69,7 +69,7 @@ impl TestGlobal {
         for (model_name, model) in self.gns.namespace().idx_models().read().iter() {
             let model_data = model.data();
             let space_uuid = space_idx.get(model_name.space()).unwrap().get_uuid();
-            let driver = ModelDriver::open_model_driver(
+            let (driver, _) = ModelDriver::open_model_driver(
                 model_data,
                 &paths_v1::model_path(
                     model_name.space(),
@@ -99,6 +99,7 @@ impl TestGlobal {
                 ErrorKind::IoError(e_) => match e_.kind() {
                     std::io::ErrorKind::AlreadyExists => {
                         GNSDriver::open_gns_with_name(log_name, &data, Default::default())
+                            .map(|(jw, _)| jw)
                     }
                     _ => Err(e),
                 },

--- a/server/src/engine/macros.rs
+++ b/server/src/engine/macros.rs
@@ -464,3 +464,11 @@ macro_rules! e {
 macro_rules! l {
     (let $($name:ident),* = $($expr:expr),*) => { let ($($name),*) = ($($expr),*); }
 }
+
+macro_rules! iff {
+    ($if:expr, $then:expr) => {
+        if $if {
+            $then
+        }
+    };
+}

--- a/server/src/engine/macros.rs
+++ b/server/src/engine/macros.rs
@@ -410,6 +410,7 @@ macro_rules! local_mut {
     }};
 }
 
+#[cfg(test)]
 macro_rules! local_ref {
     ($ident:ident, $call:expr) => {{
         #[inline(always)]

--- a/server/src/engine/mem/fixed_vec.rs
+++ b/server/src/engine/mem/fixed_vec.rs
@@ -46,6 +46,9 @@ pub struct FixedVec<T, const CAP: usize> {
     l: usize,
 }
 
+unsafe impl<T: Send, const CAP: usize> Send for FixedVec<T, CAP> {}
+unsafe impl<T: Sync, const CAP: usize> Sync for FixedVec<T, CAP> {}
+
 impl<T, const CAP: usize> Default for FixedVec<T, CAP> {
     fn default() -> Self {
         Self::allocate()

--- a/server/src/engine/mem/vinline.rs
+++ b/server/src/engine/mem/vinline.rs
@@ -46,6 +46,11 @@ pub struct VInline<const N: usize, T> {
     c: usize,
 }
 
+#[cfg(test)]
+unsafe impl<const N: usize, T: Send> Send for VInline<N, T> {}
+#[cfg(test)]
+unsafe impl<const N: usize, T: Sync> Sync for VInline<N, T> {}
+
 impl<const N: usize, T> VInline<N, T> {
     #[inline(always)]
     pub const fn new() -> Self {

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -202,3 +202,7 @@ pub fn finish(g: fractal::Global) {
 pub fn repair() -> RuntimeResult<()> {
     storage::repair()
 }
+
+pub fn compact() -> RuntimeResult<()> {
+    storage::compact()
+}

--- a/server/src/engine/net/protocol/mod.rs
+++ b/server/src/engine/net/protocol/mod.rs
@@ -82,7 +82,7 @@ pub struct ClientLocalState {
 }
 
 impl ClientLocalState {
-    pub fn new(username: Box<str>, root: bool, hs: handshake::CHandshakeStatic) -> Self {
+    fn new(username: Box<str>, root: bool, hs: handshake::CHandshakeStatic) -> Self {
         Self {
             username,
             root,
@@ -104,6 +104,20 @@ impl ClientLocalState {
     }
     pub fn get_cs(&self) -> Option<&str> {
         self.cs.as_deref()
+    }
+    #[cfg(test)]
+    pub fn test_new(username: &str, root: bool) -> Self {
+        Self::new(
+            username.into(),
+            root,
+            self::handshake::CHandshakeStatic::new(
+                HandshakeVersion::Original,
+                ProtocolVersion::Original,
+                DataExchangeMode::QueryTime,
+                QueryMode::Bql1,
+                AuthMode::Password,
+            ),
+        )
     }
 }
 

--- a/server/src/engine/storage/common/sdss/impls/sdss_r1/mod.rs
+++ b/server/src/engine/storage/common/sdss/impls/sdss_r1/mod.rs
@@ -107,7 +107,7 @@ pub trait HeaderV1Spec {
 */
 
 #[repr(align(8))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct HeaderV1<H: HeaderV1Spec> {
     // 1 magic block
     magic_header_version: HeaderVersion,

--- a/server/src/engine/storage/common/sdss/impls/sdss_r1/rw.rs
+++ b/server/src/engine/storage/common/sdss/impls/sdss_r1/rw.rs
@@ -335,6 +335,16 @@ impl<
         const CHECKSUM_WRITTEN_IF_BLOCK_ERROR: bool,
     > TrackedWriter<S, SIZE, PANIC_IF_UNFLUSHED, CHECKSUM_WRITTEN_IF_BLOCK_ERROR>
 {
+    pub fn new_full(f_d: File, f_md: S::Metadata, t_cursor: u64, t_checksum: SCrc64) -> Self {
+        Self {
+            f_d,
+            f_md,
+            t_cursor,
+            t_checksum,
+            t_partial_checksum: SCrc64::new(),
+            buf: FixedVec::allocate(),
+        }
+    }
     fn available_capacity(&self) -> usize {
         self.buf.remaining_capacity()
     }
@@ -351,6 +361,12 @@ impl<
     }
     pub fn __zero_buffer(&mut self) {
         self.buf.clear()
+    }
+    pub fn get_md(&self) -> &S::Metadata {
+        &self.f_md
+    }
+    pub fn checksum_state(&self) -> SCrc64 {
+        self.t_checksum.clone()
     }
 }
 

--- a/server/src/engine/storage/mod.rs
+++ b/server/src/engine/storage/mod.rs
@@ -61,6 +61,10 @@ pub fn repair() -> RuntimeResult<()> {
     v2::repair()
 }
 
+pub fn compact() -> RuntimeResult<()> {
+    v2::compact()
+}
+
 pub fn load(cfg: &Configuration) -> RuntimeResult<SELoaded> {
     // first determine if this is a new install, an existing install or if it uses the old driver
     if Path::new(v1::SYSDB_PATH).is_file() {

--- a/server/src/engine/storage/v2/impls/gns_log.rs
+++ b/server/src/engine/storage/v2/impls/gns_log.rs
@@ -64,6 +64,8 @@ use {
     GNS event log impl
 */
 
+pub type GNSAdapter = EventLogAdapter<GNSEventLog>;
+
 #[cfg(test)]
 local! {
     static EVENT_TRACING: ReadEventTracing = ReadEventTracing { total: 0, repeat: 0 };

--- a/server/src/engine/storage/v2/impls/mdl_journal.rs
+++ b/server/src/engine/storage/v2/impls/mdl_journal.rs
@@ -64,6 +64,8 @@ use {
     },
 };
 
+pub type ModelAdapter = BatchAdapter<ModelDataAdapter>;
+
 #[cfg(test)]
 local! {
     static BATCH_INFO: Vec<BatchInfo> = Vec::new();

--- a/server/src/engine/storage/v2/impls/mdl_journal.rs
+++ b/server/src/engine/storage/v2/impls/mdl_journal.rs
@@ -64,6 +64,23 @@ use {
     },
 };
 
+#[cfg(test)]
+local! {
+    static BATCH_INFO: Vec<BatchInfo> = Vec::new();
+}
+
+#[cfg(test)]
+#[derive(Debug, PartialEq)]
+pub struct BatchInfo {
+    pub items_count: usize,
+    pub redundant_count: usize,
+}
+
+#[cfg(test)]
+pub fn get_last_batch_run_info() -> Vec<BatchInfo> {
+    local_mut!(BATCH_INFO, |info| core::mem::take(info))
+}
+
 pub type ModelDriver = BatchDriver<ModelDataAdapter>;
 impl ModelDriver {
     pub fn open_model_driver(
@@ -333,17 +350,10 @@ impl<'a> FullModel<'a> {
     pub fn new(model: &'a ModelData) -> Self {
         Self(model)
     }
-}
-
-impl<'a> JournalAdapterEvent<BatchAdapter<ModelDataAdapter>> for FullModel<'a> {
-    fn md(&self) -> u64 {
-        BatchType::Standard.dscr_u64()
-    }
-    fn write_direct(
+    fn write<const ZERO: bool>(
         self,
-        f: &mut TrackedWriter<<BatchAdapter<ModelDataAdapter> as RawJournalAdapter>::Spec>,
-        _: Rc<RefCell<BatchStats>>,
-    ) -> RuntimeResult<()> {
+        f: &mut TrackedWriter<ModelDataBatchAofV1>,
+    ) -> Result<(), crate::engine::fractal::error::Error> {
         let g = pin();
         let mut row_writer: RowWriter<'_> = RowWriter { f };
         let index = self.0.primary_index().__raw_index();
@@ -356,7 +366,14 @@ impl<'a> JournalAdapterEvent<BatchAdapter<ModelDataAdapter>> for FullModel<'a> {
         row_writer.write_row_global_metadata(self.0)?;
         for (key, row_data) in index.mt_iter_kv(&g) {
             let row_data = row_data.read();
-            row_writer.write_row_metadata(DataDeltaKind::Insert, row_data.get_txn_revised())?;
+            row_writer.write_row_metadata(
+                DataDeltaKind::Insert,
+                if ZERO {
+                    DeltaVersion::genesis()
+                } else {
+                    row_data.get_txn_revised()
+                },
+            )?;
             row_writer.write_row_pk(key)?;
             row_writer.write_row_data(self.0, &row_data)?;
         }
@@ -365,6 +382,19 @@ impl<'a> JournalAdapterEvent<BatchAdapter<ModelDataAdapter>> for FullModel<'a> {
             .f
             .dtrack_write(&current_row_count.u64_bytes_le())?;
         Ok(())
+    }
+}
+
+impl<'a> JournalAdapterEvent<BatchAdapter<ModelDataAdapter>> for FullModel<'a> {
+    fn md(&self) -> u64 {
+        BatchType::Standard.dscr_u64()
+    }
+    fn write_direct(
+        self,
+        f: &mut TrackedWriter<<BatchAdapter<ModelDataAdapter> as RawJournalAdapter>::Spec>,
+        _: Rc<RefCell<BatchStats>>,
+    ) -> RuntimeResult<()> {
+        self.write::<false>(f)
     }
 }
 
@@ -434,6 +464,20 @@ impl BatchStats {
     }
 }
 
+struct ModelConslidation<'a>(&'a ModelData);
+impl<'a> JournalAdapterEvent<BatchAdapter<ModelDataAdapter>> for ModelConslidation<'a> {
+    fn md(&self) -> u64 {
+        BatchType::Standard.dscr_u64()
+    }
+    fn write_direct(
+        self,
+        f: &mut TrackedWriter<<BatchAdapter<ModelDataAdapter> as RawJournalAdapter>::Spec>,
+        _: <BatchAdapter<ModelDataAdapter> as RawJournalAdapter>::CommitContext,
+    ) -> RuntimeResult<()> {
+        FullModel(self.0).write::<true>(f)
+    }
+}
+
 impl BatchAdapterSpec for ModelDataAdapter {
     type Spec = ModelDataBatchAofV1;
     type GlobalState = ModelData;
@@ -447,7 +491,14 @@ impl BatchAdapterSpec for ModelDataAdapter {
         writer: &mut ModelDriver,
         ctx: Self::FullSyncCtx<'a>,
     ) -> RuntimeResult<()> {
-        writer.commit_with_ctx(FullModel(ctx), BatchStats::new())
+        /*
+            a batch consolidation is our opportunity to fully reset version counters to genesis (+1 because of fetch add).
+            basically after the compaction "all events already happened" and the next event to happen will have ID 1
+        */
+        writer.commit_with_ctx(ModelConslidation(ctx), BatchStats::new())?;
+        ctx.delta_state()
+            .__set_delta_version(DeltaVersion::__new(1));
+        Ok(())
     }
     fn is_early_exit(event_type: &Self::EventType) -> bool {
         EventType::EarlyExit.eq(event_type)
@@ -539,6 +590,8 @@ impl BatchAdapterSpec for ModelDataAdapter {
         let m = gs;
         let mut real_last_txn_id = DeltaVersion::genesis();
         let mut redundant_records = 0;
+        #[cfg(test)]
+        let ev_count = batch_state.events.len();
         for DecodedBatchEvent { txn_id, pk, kind } in batch_state.events {
             match kind {
                 DecodedBatchEventKind::Insert(new_row)
@@ -665,6 +718,13 @@ impl BatchAdapterSpec for ModelDataAdapter {
         m.delta_state()
             .__set_delta_version(DeltaVersion::__new(real_last_txn_id.value_u64() + 1));
         heuristics.report_additional_redundant_records(redundant_records);
+        #[cfg(test)]
+        {
+            local_mut!(BATCH_INFO, |info| info.push(BatchInfo {
+                items_count: ev_count,
+                redundant_count: redundant_records
+            }))
+        }
         Ok(())
     }
 }

--- a/server/src/engine/storage/v2/impls/mdl_journal.rs
+++ b/server/src/engine/storage/v2/impls/mdl_journal.rs
@@ -442,6 +442,13 @@ impl BatchAdapterSpec for ModelDataAdapter {
     type BatchMetadata = BatchMetadata;
     type BatchState = BatchRestoreState;
     type CommitContext = Rc<RefCell<BatchStats>>;
+    type FullSyncCtx<'a> = &'a Self::GlobalState;
+    fn consolidate_batch<'a>(
+        writer: &mut ModelDriver,
+        ctx: Self::FullSyncCtx<'a>,
+    ) -> RuntimeResult<()> {
+        writer.commit_with_ctx(FullModel(ctx), BatchStats::new())
+    }
     fn is_early_exit(event_type: &Self::EventType) -> bool {
         EventType::EarlyExit.eq(event_type)
     }

--- a/server/src/engine/storage/v2/impls/tests/gns.rs
+++ b/server/src/engine/storage/v2/impls/tests/gns.rs
@@ -32,6 +32,7 @@ use crate::engine::{
     idx::STIndex,
     net::protocol::ClientLocalState,
     storage::{
+        common::interface::fs::{FSContext, FileSystem},
         v2::{
             impls::gns_log::{self, ReadEventTracing},
             raw::journal,
@@ -43,6 +44,9 @@ use crate::engine::{
 
 #[test]
 fn compaction_test() {
+    FileSystem::set_context(FSContext::Local);
+    let mut fs = FileSystem::instance();
+    fs.mark_file_for_removal("compaction_test_gns");
     let global = TestGlobal::new_with_driver_id("compaction_test_gns");
     // create a space
     super::exec(
@@ -107,6 +111,7 @@ fn compaction_test() {
         GNSDriver::close_driver(&mut new_jrnl).unwrap();
     }
     let tg = thread::spawn(|| {
+        FileSystem::set_context(FSContext::Local);
         let tg = TestGlobal::new_with_driver_id("compaction_test_gns");
         assert_eq!(
             gns_log::get_tracing(),

--- a/server/src/engine/storage/v2/impls/tests/gns.rs
+++ b/server/src/engine/storage/v2/impls/tests/gns.rs
@@ -1,0 +1,142 @@
+/*
+ * Created on Sun Apr 21 2024
+ *
+ * This file is a part of Skytable
+ * Skytable (formerly known as TerrabaseDB or Skybase) is a free and open-source
+ * NoSQL database written by Sayan Nandan ("the Author") with the
+ * vision to provide flexibility in data modelling without compromising
+ * on performance, queryability or scalability.
+ *
+ * Copyright (c) 2024, Sayan Nandan <nandansayan@outlook.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+*/
+
+use std::thread;
+
+use crate::engine::{
+    core::{dcl, model::ModelData, space::Space, system_db::VerifyUser, EntityIDRef},
+    fractal::{test_utils::TestGlobal, GlobalInstanceLike},
+    idx::STIndex,
+    net::protocol::ClientLocalState,
+    storage::{
+        v2::{
+            impls::gns_log::{self, ReadEventTracing},
+            raw::journal,
+        },
+        GNSDriver,
+    },
+    txn::gns::sysctl::AlterUserTxn,
+};
+
+#[test]
+fn compaction_test() {
+    let global = TestGlobal::new_with_driver_id("compaction_test_gns");
+    // create a space
+    super::exec(
+        &global,
+        "create space myspace",
+        Space::transactional_exec_create,
+    )
+    .unwrap();
+    // create a model and alter
+    super::exec(
+        &global,
+        "create model myspace.mymodel(username: string, password: string, phone: uint64)",
+        ModelData::transactional_exec_create,
+    )
+    .unwrap();
+    super::exec(
+        &global,
+        "alter model myspace.mymodel update phone { nullable: true }",
+        ModelData::transactional_exec_alter,
+    )
+    .unwrap();
+    // create an user and alter
+    super::exec_step(
+        &global,
+        "sysctl create user sayan with { password: 'mypassword12345678' }",
+        1,
+        |g, n| dcl::exec_ref(g, &ClientLocalState::test_new("root", true), n),
+    )
+    .unwrap();
+    super::exec_step(
+        &global,
+        "sysctl alter user sayan with { password: 'mypassword23456789' }",
+        1,
+        |g, n| dcl::exec_ref(g, &ClientLocalState::test_new("root", true), n),
+    )
+    .unwrap();
+    assert_eq!(gns_log::get_executed_event_count(), 5);
+    {
+        // now shut down global
+        let (gns_data, old_driver) = global.finish_into_driver();
+        // compact journal
+        let mut new_jrnl =
+            journal::compact_journal::<true, _>("compaction_test_gns", old_driver, &gns_data)
+                .unwrap();
+        assert_eq!(
+            gns_log::get_executed_event_count(),
+            3, // create space, create model, create user
+        );
+        // commit this event
+        new_jrnl
+            .commit_event(AlterUserTxn::new(
+                "sayan",
+                &rcrypt::hash(
+                    "hickory dickory dock, the mouse didn't go up the clock",
+                    rcrypt::DEFAULT_COST,
+                )
+                .unwrap(),
+            ))
+            .unwrap();
+        assert_eq!(gns_log::get_executed_event_count(), 1);
+        // close
+        GNSDriver::close_driver(&mut new_jrnl).unwrap();
+    }
+    let tg = thread::spawn(|| {
+        let tg = TestGlobal::new_with_driver_id("compaction_test_gns");
+        assert_eq!(
+            gns_log::get_tracing(),
+            ReadEventTracing {
+                total: 4,  // create space, create model, create user, alter user (post compaction)
+                repeat: 1, // the last alter after compaction
+            }
+        );
+        tg
+    })
+    .join()
+    .unwrap();
+    assert_eq!(
+        tg.state().namespace().sys_db().verify_user(
+            "sayan",
+            b"hickory dickory dock, the mouse didn't go up the clock"
+        ),
+        VerifyUser::Okay
+    );
+    assert!(tg.state().namespace().idx().read().contains_key("myspace"));
+    assert!(tg
+        .state()
+        .namespace()
+        .idx_models()
+        .read()
+        .get(&EntityIDRef::new("myspace", "mymodel"))
+        .unwrap()
+        .data()
+        .fields()
+        .st_get("phone")
+        .unwrap()
+        .is_nullable());
+}

--- a/server/src/engine/storage/v2/impls/tests/mod.rs
+++ b/server/src/engine/storage/v2/impls/tests/mod.rs
@@ -24,4 +24,34 @@
  *
 */
 
+use crate::engine::{
+    fractal::test_utils::TestGlobal,
+    ql::{
+        ast::{self, traits::ASTNode},
+        tests::lex_insecure,
+    },
+};
+
+mod gns;
 mod model_driver;
+
+fn exec<'a, N: ASTNode<'a>, T>(
+    global: &TestGlobal,
+    query: &'a str,
+    and_then: impl FnOnce(&TestGlobal, N) -> T,
+) -> T {
+    self::exec_step(global, query, 2, and_then)
+}
+
+fn exec_step<'a, N: ASTNode<'a>, T>(
+    global: &TestGlobal,
+    query: &'a str,
+    step: usize,
+    and_then: impl FnOnce(&TestGlobal, N) -> T,
+) -> T {
+    let tokens = lex_insecure(query.as_bytes()).unwrap();
+    let query: N =
+        ast::parse_ast_node_full(unsafe { core::mem::transmute(&tokens[step..]) }).unwrap();
+    let r = and_then(global, query);
+    r
+}

--- a/server/src/engine/storage/v2/impls/tests/model_driver/compaction_test.rs
+++ b/server/src/engine/storage/v2/impls/tests/model_driver/compaction_test.rs
@@ -1,0 +1,214 @@
+/*
+ * Created on Sun Apr 21 2024
+ *
+ * This file is a part of Skytable
+ * Skytable (formerly known as TerrabaseDB or Skybase) is a free and open-source
+ * NoSQL database written by Sayan Nandan ("the Author") with the
+ * vision to provide flexibility in data modelling without compromising
+ * on performance, queryability or scalability.
+ *
+ * Copyright (c) 2024, Sayan Nandan <nandansayan@outlook.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+*/
+
+use {
+    crate::engine::{
+        core::EntityIDRef,
+        data::lit::Lit,
+        fractal::{test_utils::TestGlobal, GlobalInstanceLike},
+        storage::{
+            common::paths_v1,
+            v2::{
+                impls::mdl_journal::{self, BatchInfo},
+                raw::journal,
+            },
+        },
+    },
+    crossbeam_epoch::pin,
+    std::thread,
+};
+
+#[test]
+fn compaction_test() {
+    let driver_path;
+    {
+        /*
+            create a model and apply 2000 events to it, with 1:1 redundancy ratio
+        */
+        let global = TestGlobal::new_with_driver_id_instant_update("compaction_test");
+        super::create_model_and_space(
+            &global,
+            "create model compaction_test.compaction_test(username: string, password: string)",
+        )
+        .unwrap();
+        for (key, val) in super::create_test_kv_strings(1000) {
+            super::run_insert(
+                &global,
+                &format!("insert into compaction_test.compaction_test('{key}', '{val}')"),
+            )
+            .unwrap();
+            super::run_update(
+                &global,
+                &format!("update compaction_test.compaction_test set password = 'password' where username = '{key}'"),
+            )
+            .unwrap()
+        }
+        assert_eq!(global.get_net_commited_events(), 2000);
+        /*
+            get the model driver and compact it
+        */
+        {
+            let space_uuid = global
+                .state()
+                .namespace()
+                .idx()
+                .read()
+                .get("compaction_test")
+                .unwrap()
+                .get_uuid();
+            let mut idx_models = global.state().namespace().idx_models().write();
+            let mdl = idx_models
+                .get_mut(&EntityIDRef::new("compaction_test", "compaction_test"))
+                .unwrap();
+            let mut driver = mdl.driver().batch_driver().lock();
+            let orig_driver = driver.take();
+            // now we want to compact this
+            driver_path = paths_v1::model_path(
+                "compaction_test",
+                space_uuid,
+                "compaction_test",
+                mdl.data().get_uuid(),
+            );
+            let new_jrnl =
+                journal::compact_journal::<true, _>(&driver_path, orig_driver.unwrap(), mdl.data())
+                    .unwrap();
+            let _ = driver.replace(new_jrnl);
+        }
+        /*
+            write two more events (net = 1002) (ref (1) and (2))
+        */
+        for (k, v) in (1001..=1002).map(|i| super::create_test_kv(i, 1000)) {
+            super::run_insert(
+                &global,
+                &format!("insert into compaction_test.compaction_test('{k}', '{v}')"),
+            )
+            .unwrap();
+        }
+        assert_eq!(global.get_net_commited_events(), 2002);
+        drop(global);
+    }
+    /*
+        reopen the model and verify data. separate thread to ensure new local state
+    */
+    let global = thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || {
+            let global = TestGlobal::new_with_driver_id("compaction_test");
+            let last_batch_runs = mdl_journal::get_last_batch_run_info();
+            assert_eq!(
+                last_batch_runs,
+                vec![
+                    BatchInfo {
+                        items_count: 1000,
+                        redundant_count: 0
+                    }, // we consolidated this one
+                    BatchInfo {
+                        items_count: 1,
+                        redundant_count: 0
+                    }, // this was after the consolidation (1)
+                    BatchInfo {
+                        items_count: 1,
+                        redundant_count: 0
+                    }, // this was after the consolidation (2)
+                ]
+            );
+            global
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+    let models = global.state().namespace().idx_models().read();
+    let mdl = models
+        .get(&EntityIDRef::new("compaction_test", "compaction_test"))
+        .unwrap();
+    assert_eq!(mdl.data().primary_index().count(), 1002);
+    let pin = pin();
+    /*
+        verify the pre compaction rows
+    */
+    for (key, _) in super::create_test_kv_strings(1000) {
+        let row = mdl
+            .data()
+            .primary_index()
+            .select(Lit::new_str(&key), &pin)
+            .unwrap()
+            .d_data()
+            .read();
+        assert_eq!(
+            row.fields()
+                .get("password")
+                .unwrap()
+                .clone()
+                .into_str()
+                .unwrap(),
+            "password"
+        );
+        // alll pre compaction rows are set to txn id 0
+        assert_eq!(row.get_txn_revised().value_u64(), 0);
+    }
+    /*
+        verify the post compaction rows
+    */
+    let kv_1001 = super::create_test_kv(1001, 1000);
+    let kv_1002 = super::create_test_kv(1002, 1000);
+
+    let row_1001 = mdl
+        .data()
+        .primary_index()
+        .select(Lit::new_str(&kv_1001.0), &pin)
+        .unwrap()
+        .d_data()
+        .read();
+    assert_eq!(
+        row_1001
+            .fields()
+            .get("password")
+            .unwrap()
+            .clone()
+            .into_str()
+            .unwrap(),
+        kv_1001.1
+    );
+    assert_eq!(row_1001.get_txn_revised().value_u64(), 1);
+    let row_1002 = mdl
+        .data()
+        .primary_index()
+        .select(Lit::new_str(&kv_1002.0), &pin)
+        .unwrap()
+        .d_data()
+        .read();
+    assert_eq!(
+        row_1002
+            .fields()
+            .get("password")
+            .unwrap()
+            .clone()
+            .into_str()
+            .unwrap(),
+        kv_1002.1
+    );
+    assert_eq!(row_1002.get_txn_revised().value_u64(), 2);
+}

--- a/server/src/engine/storage/v2/impls/tests/model_driver/generic.rs
+++ b/server/src/engine/storage/v2/impls/tests/model_driver/generic.rs
@@ -27,68 +27,14 @@
 use {
     crate::{
         engine::{
-            core::{dml, index::RowData, model::ModelData, space::Space, EntityID, EntityIDRef},
+            core::{index::RowData, EntityIDRef},
             data::lit::Lit,
-            error::QueryResult,
             fractal::{test_utils::TestGlobal, GlobalInstanceLike},
-            ql::{
-                ast,
-                ddl::crt::{CreateModel, CreateSpace},
-                dml::{ins::InsertStatement, upd::UpdateStatement},
-                tests::lex_insecure,
-            },
         },
         util::test_utils,
     },
     crossbeam_epoch::pin,
 };
-
-const TEST_DATASET_SIZE: usize = 1000;
-const TEST_UPDATE_DATASET_SIZE: usize = 8200; // this peculiar size to force the buffer to flush
-
-fn create_test_kv_strings(change_count: usize) -> Vec<(String, String)> {
-    (1..=change_count)
-        .map(|i| {
-            (
-                format!("user-{i:0>change_count$}"),
-                format!("password-{i:0>change_count$}"),
-            )
-        })
-        .collect()
-}
-
-fn create_test_kv_int(change_count: usize) -> Vec<(u64, String)> {
-    (0..change_count)
-        .map(|i| (i as u64, format!("password-{i:0>change_count$}")))
-        .collect()
-}
-
-fn create_model_and_space(global: &TestGlobal, create_model: &str) -> QueryResult<EntityID> {
-    let tokens = lex_insecure(create_model.as_bytes()).unwrap();
-    let create_model: CreateModel = ast::parse_ast_node_full(&tokens[2..]).unwrap();
-    let mdl_name = EntityID::new(
-        create_model.model_name.space(),
-        create_model.model_name.entity(),
-    );
-    // first create space
-    let create_space_str = format!("create space {}", create_model.model_name.space());
-    let create_space_tokens = lex_insecure(create_space_str.as_bytes()).unwrap();
-    let create_space: CreateSpace = ast::parse_ast_node_full(&create_space_tokens[2..]).unwrap();
-    Space::transactional_exec_create(global, create_space)?;
-    ModelData::transactional_exec_create(global, create_model).map(|_| mdl_name)
-}
-
-fn run_insert(global: &TestGlobal, insert: &str) -> QueryResult<()> {
-    let tokens = lex_insecure(insert.as_bytes()).unwrap();
-    let insert: InsertStatement = ast::parse_ast_node_full(&tokens[1..]).unwrap();
-    dml::insert(global, insert)
-}
-
-fn run_update(global: &TestGlobal, update: &str) -> QueryResult<()> {
-    let tokens = lex_insecure(update.as_bytes()).unwrap();
-    let insert: UpdateStatement = ast::parse_ast_node_full(&tokens[1..]).unwrap();
-    dml::update(global, insert)
-}
 
 fn auto_hook<T>(msg: &str, f: impl Fn() -> T) -> T {
     let hook = std::panic::take_hook();
@@ -107,7 +53,7 @@ fn create_and_close(log_name: &str, decl: &str) {
             // create and close
             {
                 let global = TestGlobal::new_with_driver_id(log_name);
-                let _ = create_model_and_space(&global, decl).unwrap();
+                let _ = super::create_model_and_space(&global, decl).unwrap();
             }
             // open
             {
@@ -133,9 +79,9 @@ fn run_sample_inserts<K, V>(
             {
                 let mut global = TestGlobal::new_with_driver_id(log_name);
                 global.set_max_data_pressure(key_values.len());
-                mdl_name = create_model_and_space(&global, decl).unwrap();
+                mdl_name = super::create_model_and_space(&global, decl).unwrap();
                 for (username, password) in key_values.iter() {
-                    run_insert(&global, &make_insert_query(username, password)).unwrap();
+                    super::run_insert(&global, &make_insert_query(username, password)).unwrap();
                 }
             }
             // reopen and verify 100 times
@@ -176,73 +122,76 @@ fn run_sample_updates<K, V>(
     check_row: impl Fn(&K, &V, &RowData),
 ) {
     auto_hook(decl, || {
-        test_utils::with_variable((log_name, TEST_UPDATE_DATASET_SIZE), |(log_name, n)| {
-            /*
-                - we first open the log and then insert n values
-                - we then reopen the log 100 times, changing n / 100 values every time (we set the string to an empty one)
-                - we finally reopen the log and check if all the keys have empty string as the password
-            */
-            let mdl_name;
-            {
-                // insert n values
-                let mut global = TestGlobal::new_with_driver_id(log_name);
-                global.set_max_data_pressure(n);
-                mdl_name = create_model_and_space(&global, decl).unwrap();
-                for (username, password) in key_values.iter() {
-                    run_insert(&global, &make_insert_query(username, password)).unwrap();
-                }
-            }
-            {
-                // reopen and update multiple times
-                // this effectively opens the log 100 times
-                let changes_per_cycle = n / 10;
-                let reopen_count = n / changes_per_cycle;
-                // now update values
-                let mut actual_position = 0;
-                for _ in 0..reopen_count {
-                    let mut global = TestGlobal::new_with_driver_id(log_name);
-                    global.set_max_data_pressure(changes_per_cycle);
-                    let mut j = 0;
-                    for _ in 0..changes_per_cycle {
-                        let (username, pass) = &key_values[actual_position];
-                        run_update(&global, &make_update_query(username, pass)).unwrap();
-                        actual_position += 1;
-                        j += 1;
-                    }
-                    assert_eq!(j, changes_per_cycle);
-                    drop(global);
-                }
-                assert_eq!(actual_position, n);
-            }
-            {
-                let global = TestGlobal::new_with_driver_id(log_name);
-                for (txn_id, (username, password)) in key_values
-                    .iter()
-                    .enumerate()
-                    .map(|(i, x)| ((i + n) as u64, x))
+        test_utils::with_variable(
+            (log_name, super::TEST_UPDATE_DATASET_SIZE),
+            |(log_name, n)| {
+                /*
+                    - we first open the log and then insert n values
+                    - we then reopen the log 100 times, changing n / 100 values every time (we set the string to an empty one)
+                    - we finally reopen the log and check if all the keys have empty string as the password
+                */
+                let mdl_name;
                 {
-                    global
-                        .state()
-                        .namespace()
-                        .with_model(
-                            EntityIDRef::new(mdl_name.space(), mdl_name.entity()),
-                            |model| {
-                                let g = pin();
-                                let row = model
-                                    .primary_index()
-                                    .select(as_pk(username), &g)
-                                    .unwrap()
-                                    .d_data()
-                                    .read();
-                                check_row(username, password, &row);
-                                assert_eq!(row.get_txn_revised().value_u64(), txn_id);
-                                Ok(())
-                            },
-                        )
-                        .unwrap();
+                    // insert n values
+                    let mut global = TestGlobal::new_with_driver_id(log_name);
+                    global.set_max_data_pressure(n);
+                    mdl_name = super::create_model_and_space(&global, decl).unwrap();
+                    for (username, password) in key_values.iter() {
+                        super::run_insert(&global, &make_insert_query(username, password)).unwrap();
+                    }
                 }
-            }
-        })
+                {
+                    // reopen and update multiple times
+                    // this effectively opens the log 100 times
+                    let changes_per_cycle = n / 10;
+                    let reopen_count = n / changes_per_cycle;
+                    // now update values
+                    let mut actual_position = 0;
+                    for _ in 0..reopen_count {
+                        let mut global = TestGlobal::new_with_driver_id(log_name);
+                        global.set_max_data_pressure(changes_per_cycle);
+                        let mut j = 0;
+                        for _ in 0..changes_per_cycle {
+                            let (username, pass) = &key_values[actual_position];
+                            super::run_update(&global, &make_update_query(username, pass)).unwrap();
+                            actual_position += 1;
+                            j += 1;
+                        }
+                        assert_eq!(j, changes_per_cycle);
+                        drop(global);
+                    }
+                    assert_eq!(actual_position, n);
+                }
+                {
+                    let global = TestGlobal::new_with_driver_id(log_name);
+                    for (txn_id, (username, password)) in key_values
+                        .iter()
+                        .enumerate()
+                        .map(|(i, x)| ((i + n) as u64, x))
+                    {
+                        global
+                            .state()
+                            .namespace()
+                            .with_model(
+                                EntityIDRef::new(mdl_name.space(), mdl_name.entity()),
+                                |model| {
+                                    let g = pin();
+                                    let row = model
+                                        .primary_index()
+                                        .select(as_pk(username), &g)
+                                        .unwrap()
+                                        .d_data()
+                                        .read();
+                                    check_row(username, password, &row);
+                                    assert_eq!(row.get_txn_revised().value_u64(), txn_id);
+                                    Ok(())
+                                },
+                            )
+                            .unwrap();
+                    }
+                }
+            },
+        )
     })
 }
 
@@ -267,7 +216,7 @@ fn model_data_inserts() {
     run_sample_inserts(
         "model_data_inserts_variable_pk",
         "create model apps.social(user_name: string, password: string)",
-        create_test_kv_strings(TEST_DATASET_SIZE),
+        super::create_test_kv_strings(super::TEST_DATASET_SIZE),
         |k, v| format!("insert into apps.social('{k}', '{v}')"),
         |k| Lit::new_str(k),
         |_, v, row| assert_eq!(row.fields().get("password").unwrap().str(), v),
@@ -275,7 +224,7 @@ fn model_data_inserts() {
     run_sample_inserts(
         "model_data_inserts_fixed_pk",
         "create model apps.social(user_id: uint64, password: string)",
-        create_test_kv_int(TEST_DATASET_SIZE),
+        super::create_test_kv_int(super::TEST_DATASET_SIZE),
         |k, v| format!("insert into apps.social({k}, '{v}')"),
         |k| Lit::new_uint(*k),
         |_, v, row| assert_eq!(row.fields().get("password").unwrap().str(), v),
@@ -288,7 +237,7 @@ fn model_data_updates() {
     run_sample_updates(
         "model_data_updates_variable_key",
         "create model apps.social(user_name: string, password: string)",
-        create_test_kv_strings(TEST_UPDATE_DATASET_SIZE),
+        super::create_test_kv_strings(super::TEST_UPDATE_DATASET_SIZE),
         |k, v| format!("insert into apps.social('{k}', '{v}')"),
         |k, _| format!("update apps.social set password = '' where user_name = '{k}'"),
         |k| Lit::new_str(k),
@@ -303,7 +252,7 @@ fn model_data_updates() {
     run_sample_updates(
         "model_data_updates_fixed_key",
         "create model apps.social(user_name: uint64, password: string)",
-        create_test_kv_int(TEST_UPDATE_DATASET_SIZE),
+        super::create_test_kv_int(super::TEST_UPDATE_DATASET_SIZE),
         |k, v| format!("insert into apps.social({k}, '{v}')"),
         |k, _| format!("update apps.social set password = '' where user_name = {k}"),
         |k| Lit::new_uint(*k),

--- a/server/src/engine/storage/v2/impls/tests/model_driver/generic.rs
+++ b/server/src/engine/storage/v2/impls/tests/model_driver/generic.rs
@@ -30,6 +30,7 @@ use {
             core::{index::RowData, EntityIDRef},
             data::lit::Lit,
             fractal::{test_utils::TestGlobal, GlobalInstanceLike},
+            storage::common::interface::fs::{FSContext, FileSystem},
         },
         util::test_utils,
     },
@@ -201,6 +202,10 @@ fn run_sample_updates<K, V>(
 
 #[test]
 fn empty_model_data() {
+    FileSystem::set_context(FSContext::Local);
+    let mut fs = FileSystem::instance();
+    fs.mark_file_for_removal("empty_model_data_variable_index_key");
+    fs.mark_file_for_removal("empty_model_data_fixed_index_key");
     create_and_close(
         "empty_model_data_variable_index_key",
         "create model milky_way.solar_system(planet_name: string, population: uint64)",
@@ -213,6 +218,10 @@ fn empty_model_data() {
 
 #[test]
 fn model_data_inserts() {
+    FileSystem::set_context(FSContext::Local);
+    let mut fs = FileSystem::instance();
+    fs.mark_file_for_removal("model_data_inserts_variable_pk");
+    fs.mark_file_for_removal("model_data_inserts_fixed_pk");
     run_sample_inserts(
         "model_data_inserts_variable_pk",
         "create model apps.social(user_name: string, password: string)",
@@ -234,6 +243,10 @@ fn model_data_inserts() {
 #[test]
 #[cfg(not(all(target_os = "windows", target_pointer_width = "32")))]
 fn model_data_updates() {
+    FileSystem::set_context(FSContext::Local);
+    let mut fs = FileSystem::instance();
+    fs.mark_file_for_removal("model_data_updates_variable_key");
+    fs.mark_file_for_removal("model_data_updates_fixed_key");
     run_sample_updates(
         "model_data_updates_variable_key",
         "create model apps.social(user_name: string, password: string)",

--- a/server/src/engine/storage/v2/impls/tests/model_driver/skew.rs
+++ b/server/src/engine/storage/v2/impls/tests/model_driver/skew.rs
@@ -49,7 +49,7 @@ use {
             idx::{IndexBaseSpec, IndexSTSeqCns, MTIndex, STIndex},
             mem::RawStr,
             storage::{
-                common::interface::fs::FileSystem,
+                common::interface::fs::{FSContext, FileSystem},
                 v2::{impls::mdl_journal::StdModelBatch, raw::journal::JournalSettings},
                 BatchStats, ModelDriver,
             },
@@ -167,6 +167,9 @@ fn emulate_skewed<U: Sized, T: Sized, const N: usize>(
 
 #[test]
 fn skewed_insert_update_upsert_delete() {
+    FileSystem::set_context(FSContext::Local);
+    let mut fs = FileSystem::instance();
+    fs.mark_file_for_removal("skewed_insert_update_upsert_delete");
     emulate_skewed(
         "skewed_insert_update_upsert_delete",
         |model| {
@@ -294,6 +297,9 @@ fn skewed_insert_update_upsert_delete() {
 
 #[test]
 fn skewed_upsert() {
+    FileSystem::set_context(FSContext::Local);
+    let mut fs = FileSystem::instance();
+    fs.mark_file_for_removal("skewed_upsert");
     fn add_delta(version: u64, field_id_ptr: RawStr, pwd: &str, ds: &DeltaState, g: &Guard) {
         let row = Row::new(
             PrimaryIndexKey::try_from_dc(Datacell::new_str("sayan".into()).into()).unwrap(),

--- a/server/src/engine/storage/v2/impls/tests/model_driver/skew.rs
+++ b/server/src/engine/storage/v2/impls/tests/model_driver/skew.rs
@@ -76,6 +76,7 @@ fn initialize_or_reopen_model_driver(name: &str, mdl_uuid: Uuid) -> Model {
                 std::io::ErrorKind::AlreadyExists => {
                     ModelDriver::open_model_driver(mdl.data(), name, JournalSettings::default())
                         .unwrap()
+                        .0
                 }
                 _ => panic!("{e}"),
             },

--- a/server/src/engine/storage/v2/raw/journal/mod.rs
+++ b/server/src/engine/storage/v2/raw/journal/mod.rs
@@ -47,9 +47,9 @@ mod raw;
 #[cfg(test)]
 mod tests;
 pub use raw::{
-    compact_journal, create_journal, open_journal, repair_journal, JournalHeuristics,
-    JournalRepairMode, JournalSettings, JournalStats, RawJournalAdapter,
-    RawJournalAdapterEvent as JournalAdapterEvent, RepairResult,
+    compact_journal, compact_journal_direct, create_journal, open_journal, read_journal,
+    repair_journal, JournalHeuristics, JournalRepairMode, JournalSettings, JournalStats,
+    RawJournalAdapter, RawJournalAdapterEvent as JournalAdapterEvent, RepairResult,
 };
 
 /*

--- a/server/src/engine/storage/v2/raw/journal/raw/mod.rs
+++ b/server/src/engine/storage/v2/raw/journal/raw/mod.rs
@@ -945,6 +945,10 @@ impl JournalHeuristics {
     pub fn report_new_redundant_record(&mut self) {
         self.report_additional_redundant_records(1)
     }
+    #[cfg(test)]
+    pub fn get_current_redundant(&self) -> usize {
+        self.redundant_records
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/server/src/engine/storage/v2/raw/journal/raw/mod.rs
+++ b/server/src/engine/storage/v2/raw/journal/raw/mod.rs
@@ -31,11 +31,11 @@ use {
     crate::{
         engine::{
             error::{ErrorKind, StorageError, TransactionError},
-            fractal::error::Error,
+            fractal::{context, error::Error},
             mem::unsafe_apis::memcpy,
             storage::common::{
                 checksum::SCrc64,
-                interface::fs::FileWriteExt,
+                interface::fs::{File, FileExt, FileSystem, FileWriteExt},
                 sdss::sdss_r1::{
                     rw::{SdssFile, TrackedReader, TrackedWriter},
                     FileSpecV1,
@@ -105,6 +105,77 @@ where
 {
     let log = SdssFile::<J::Spec>::open(log_path)?;
     RawJournalReader::<J>::repair(log, gs, settings, repair_mode).map(|(lost, ..)| lost)
+}
+
+pub fn compact_journal<'a, const LOG: bool, J: RawJournalAdapter>(
+    original_journal_path: &str,
+    mut original_journal: RawJournalWriter<J>,
+    full_sync_ctx: J::FullSyncCtx<'a>,
+) -> RuntimeResult<RawJournalWriter<J>>
+where
+    <J as RawJournalAdapter>::Spec: FileSpecV1<DecodeArgs = (), EncodeArgs = ()>,
+    <<J as RawJournalAdapter>::Spec as FileSpecV1>::Metadata: Clone,
+{
+    /*
+        (1) safely close journal currently pointed to
+        ---
+        we might suffer a memory blowup or whatever and this might cause unsafe cleanup of the journal. hence,
+        we want to make sure that the good journal is not touched until we are fully sure of the status
+    */
+    context::set_dmsg("closing current journal");
+    iff!(LOG, info!("safely closing journal {original_journal_path}"));
+    RawJournalWriter::close_driver(&mut original_journal)?;
+    drop(original_journal);
+    /*
+        (2) create intermediate journal
+    */
+    let temporary_journal_path = format!("{original_journal_path}-compacted");
+    iff!(
+        LOG,
+        info!(
+            "beginning compaction of journal {original_journal_path} into {temporary_journal_path}"
+        )
+    );
+    context::set_dmsg("creating new journal for compaction");
+    let mut intermediary_jrnl = create_journal::<J>(&temporary_journal_path)?;
+    /*
+        (3) sync all optimized records to intermediate
+    */
+    context::set_dmsg("syncing optimized journal");
+    iff!(
+        LOG,
+        info!("syncing optimized journal into {temporary_journal_path}")
+    );
+    J::rewrite_full_journal(&mut intermediary_jrnl, full_sync_ctx)?;
+    /*
+        (4) temporarily close new file descriptor
+    */
+    context::set_dmsg("temporarily closing descriptor of new compaction target");
+    let compacted_jrnl_state = intermediary_jrnl.close_and_cleanup()?;
+    /*
+        (5) point to new journal
+    */
+    context::set_dmsg("pointing {temporary_journal_path} to {original_journal_path}");
+    iff!(LOG, info!("updating currently active journal"));
+    FileSystem::rename(&temporary_journal_path, original_journal_path)?;
+    /*
+        (6) reopen
+        ---
+        resume state, only verify I/O stream position
+    */
+    context::set_dmsg("reopening compacted journal and restoring state");
+    let jrnl = RawJournalWriter::<J>::load_using_backup(
+        J::initialize(&JournalInitializer::new(
+            compacted_jrnl_state.log_file_cursor,
+            compacted_jrnl_state.log_file_checksum.clone(),
+            compacted_jrnl_state.adapter_txn_id,
+            compacted_jrnl_state.adapter_known_txn_offset,
+        )),
+        original_journal_path,
+        compacted_jrnl_state,
+    )?;
+    iff!(LOG, info!("successfully compacted {original_journal_path}"));
+    Ok(jrnl)
 }
 
 #[derive(Debug)]
@@ -310,6 +381,12 @@ pub trait RawJournalAdapter: Sized {
     type CommitContext;
     /// a type representing the event kind
     type EventMeta;
+    /// the context needed for a full sync of the journal into a (possibly) new intermediary journal
+    type FullSyncCtx<'a>;
+    fn rewrite_full_journal<'a>(
+        writer: &mut RawJournalWriter<Self>,
+        full_ctx: Self::FullSyncCtx<'a>,
+    ) -> RuntimeResult<()>;
     /// initialize this adapter
     fn initialize(j_: &JournalInitializer) -> Self;
     /// get a write context
@@ -534,6 +611,35 @@ pub(super) enum DriverEventKind {
     +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 */
 
+pub struct JournalWriterStateBackup<J: RawJournalAdapter> {
+    log_file_md: <<J as RawJournalAdapter>::Spec as FileSpecV1>::Metadata,
+    log_file_cursor: u64,
+    log_file_checksum: SCrc64,
+    adapter_txn_id: u64,
+    adapter_known_txn_id: u64,
+    adapter_known_txn_offset: u64,
+}
+
+impl<J: RawJournalAdapter> JournalWriterStateBackup<J> {
+    fn new(
+        log_file_md: <<J as RawJournalAdapter>::Spec as FileSpecV1>::Metadata,
+        log_file_cursor: u64,
+        log_file_checksum: SCrc64,
+        adapter_txn_id: u64,
+        adapter_known_txn_id: u64,
+        adapter_known_txn_offset: u64,
+    ) -> Self {
+        Self {
+            log_file_md,
+            log_file_cursor,
+            log_file_checksum,
+            adapter_txn_id,
+            adapter_known_txn_id,
+            adapter_known_txn_offset,
+        }
+    }
+}
+
 /// A low-level journal writer
 pub struct RawJournalWriter<J: RawJournalAdapter> {
     j: J,
@@ -541,6 +647,60 @@ pub struct RawJournalWriter<J: RawJournalAdapter> {
     txn_id: u64,
     known_txn_id: u64,
     known_txn_offset: u64, // if offset is 0, txn id is unset
+}
+
+impl<J: RawJournalAdapter> RawJournalWriter<J> {
+    /// _Forget_ this journal, returning information about the journal's state that can be used to restore the current state later
+    /// using [`Self::load_using_backup`]
+    ///
+    /// **☢☢ WARNING ☢☢** The journal is **never closed** when this is called. Only the file descriptor is.
+    fn close_and_cleanup(mut self) -> RuntimeResult<JournalWriterStateBackup<J>>
+    where
+        <<J as RawJournalAdapter>::Spec as FileSpecV1>::Metadata: Clone,
+    {
+        // fsync + verify cursor
+        self.log_file.flush_sync()?;
+        self.log_file.verify_cursor()?;
+        Ok(JournalWriterStateBackup::new(
+            self.log_file.get_md().clone(),
+            self.log_file.cursor(),
+            self.log_file.checksum_state(),
+            self.txn_id,
+            self.known_txn_id,
+            self.known_txn_offset,
+        ))
+    }
+    /// Restore the journal state due after temporary closure of descriptor.
+    ///
+    /// **☢☢ WARNING ☢☢** The journal is **never reopened** when this is called. Only the file descriptor is.
+    fn load_using_backup(
+        adapter: J,
+        journal_path: &str,
+        JournalWriterStateBackup {
+            log_file_md,
+            log_file_cursor,
+            log_file_checksum,
+            adapter_txn_id,
+            adapter_known_txn_id,
+            adapter_known_txn_offset,
+        }: JournalWriterStateBackup<J>,
+    ) -> RuntimeResult<Self>
+    where
+        <J as RawJournalAdapter>::Spec: FileSpecV1<DecodeArgs = ()>,
+    {
+        let mut f = File::open(journal_path)?;
+        f.f_seek_start(log_file_cursor)?;
+        let mut log_file =
+            TrackedWriter::<J::Spec>::new_full(f, log_file_md, log_file_cursor, log_file_checksum);
+        log_file.verify_cursor()?;
+        Ok(Self {
+            j: adapter,
+            log_file,
+            txn_id: adapter_txn_id,
+            known_txn_id: adapter_known_txn_id,
+            known_txn_offset: adapter_known_txn_offset,
+        })
+    }
 }
 
 impl<J: RawJournalAdapter + fmt::Debug> fmt::Debug for RawJournalWriter<J>
@@ -787,9 +947,22 @@ impl JournalHeuristics {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Recommendation {
+    NoActionNeeded,
+    CompactDrvHighRatio,
+    CompactRedHighRatio,
+}
+
+impl Recommendation {
+    pub const fn needs_compaction(&self) -> bool {
+        matches!(self, Self::CompactDrvHighRatio | Self::CompactRedHighRatio)
+    }
+}
+
 impl JournalStats {
     /// Returns true if a compaction would be prudent
-    pub fn compaction_recommended(&self) -> bool {
+    pub fn recommended_action(&self) -> Recommendation {
         let minimum_file_size_compaction_trigger: usize = if cfg!(test) {
             (DriverEvent::FULL_EVENT_SIZE * 10) + self.header
         } else {
@@ -803,9 +976,15 @@ impl JournalStats {
         } else {
             (self.heuristics.redundant_records as f64 / self.server_events as f64) * 100.00
         };
-        self.file_size >= minimum_file_size_compaction_trigger
-            && (driver_event_percentage >= server_event_percentage
-                || redundant_record_percentage >= 10.0)
+        if self.file_size >= minimum_file_size_compaction_trigger {
+            if driver_event_percentage >= server_event_percentage {
+                return Recommendation::CompactDrvHighRatio;
+            }
+            if redundant_record_percentage >= 10.0 {
+                return Recommendation::CompactRedHighRatio;
+            }
+        }
+        Recommendation::NoActionNeeded
     }
     fn new<J: RawJournalAdapter>() -> Self {
         Self {

--- a/server/src/engine/storage/v2/raw/journal/raw/tests/compaction.rs
+++ b/server/src/engine/storage/v2/raw/journal/raw/tests/compaction.rs
@@ -205,8 +205,8 @@ impl<'a> RawJournalAdapterEvent<CompactDBAdapter> for Insert<'a> {
         buf: &mut Vec<u8>,
         _: <CompactDBAdapter as RawJournalAdapter>::CommitContext,
     ) {
-        buf.extend(&self.0.len().to_le_bytes());
-        buf.extend(&self.1.len().to_le_bytes());
+        buf.extend(&(self.0.len() as u64).to_le_bytes());
+        buf.extend(&(self.1.len() as u64).to_le_bytes());
         buf.extend(self.0.as_bytes());
         buf.extend(self.1.as_bytes());
     }
@@ -222,8 +222,8 @@ impl<'a> RawJournalAdapterEvent<CompactDBAdapter> for Update<'a> {
         buf: &mut Vec<u8>,
         _: <CompactDBAdapter as RawJournalAdapter>::CommitContext,
     ) {
-        buf.extend(&self.0.len().to_le_bytes());
-        buf.extend(&self.1.len().to_le_bytes());
+        buf.extend(&(self.0.len() as u64).to_le_bytes());
+        buf.extend(&(self.1.len() as u64).to_le_bytes());
         buf.extend(self.0.as_bytes());
         buf.extend(self.1.as_bytes());
     }
@@ -239,7 +239,7 @@ impl<'a> RawJournalAdapterEvent<CompactDBAdapter> for Remove<'a> {
         buf: &mut Vec<u8>,
         _: <CompactDBAdapter as RawJournalAdapter>::CommitContext,
     ) {
-        buf.extend(&self.0.len().to_le_bytes());
+        buf.extend(&(self.0.len() as u64).to_le_bytes());
         buf.extend(self.0.as_bytes());
     }
 }

--- a/server/src/engine/storage/v2/raw/journal/raw/tests/compaction.rs
+++ b/server/src/engine/storage/v2/raw/journal/raw/tests/compaction.rs
@@ -1,0 +1,327 @@
+/*
+ * Created on Sat Apr 20 2024
+ *
+ * This file is a part of Skytable
+ * Skytable (formerly known as TerrabaseDB or Skybase) is a free and open-source
+ * NoSQL database written by Sayan Nandan ("the Author") with the
+ * vision to provide flexibility in data modelling without compromising
+ * on performance, queryability or scalability.
+ *
+ * Copyright (c) 2024, Sayan Nandan <nandansayan@outlook.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+*/
+
+use {
+    crate::{
+        engine::{
+            error::StorageError,
+            storage::{
+                common::sdss::sdss_r1::rw::TrackedReader,
+                v2::raw::{
+                    journal::{
+                        self,
+                        raw::{
+                            CommitPreference, JournalInitializer, RawJournalAdapterEvent,
+                            RawJournalWriter,
+                        },
+                        JournalHeuristics, JournalSettings, JournalStats, RawJournalAdapter,
+                    },
+                    spec::SystemDatabaseV1,
+                },
+            },
+            RuntimeResult,
+        },
+        util::compiler::TaggedEnum,
+    },
+    parking_lot::RwLock,
+    sky_macros::TaggedEnum,
+    std::collections::HashMap,
+};
+
+fn jinit(path: &str) -> RuntimeResult<RawJournalWriter<CompactDBAdapter>> {
+    journal::create_journal(path)
+}
+
+fn jload(
+    db: &CompactDB,
+    path: &str,
+) -> RuntimeResult<(RawJournalWriter<CompactDBAdapter>, JournalStats)> {
+    journal::open_journal(path, db, JournalSettings::default())
+}
+
+#[derive(Debug)]
+pub struct CompactDB {
+    data: RwLock<HashMap<String, String>>,
+}
+
+impl Default for CompactDB {
+    fn default() -> Self {
+        Self::new(RwLock::default())
+    }
+}
+
+impl CompactDB {
+    pub fn new(data: RwLock<HashMap<String, String>>) -> Self {
+        Self { data }
+    }
+    pub fn insert(
+        &self,
+        jrnl: &mut RawJournalWriter<CompactDBAdapter>,
+        key: String,
+        val: String,
+    ) -> RuntimeResult<()> {
+        jrnl.commit_event(Insert(&key, &val))?;
+        self.data.write().insert(key, val);
+        Ok(())
+    }
+    pub fn update(
+        &self,
+        jrnl: &mut RawJournalWriter<CompactDBAdapter>,
+        key: String,
+        val: String,
+    ) -> RuntimeResult<()> {
+        jrnl.commit_event(Update(&key, &val))?;
+        self.data.write().insert(key, val).unwrap();
+        Ok(())
+    }
+    pub fn remove(
+        &self,
+        jrnl: &mut RawJournalWriter<CompactDBAdapter>,
+        key: String,
+    ) -> RuntimeResult<()> {
+        self.data.write().remove(&key).unwrap();
+        jrnl.commit_event(Remove(&key))
+    }
+}
+
+pub struct CompactDBAdapter;
+
+#[derive(TaggedEnum, Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum CompactDBEventKind {
+    Insert = 0,
+    Update = 1,
+    Remove = 2,
+}
+
+impl RawJournalAdapter for CompactDBAdapter {
+    const COMMIT_PREFERENCE: CommitPreference = CommitPreference::Buffered;
+    type Spec = SystemDatabaseV1;
+    type GlobalState = CompactDB;
+    type Context<'a> = ();
+    type CommitContext = ();
+    type EventMeta = CompactDBEventKind;
+    fn initialize(_: &JournalInitializer) -> Self {
+        Self
+    }
+    fn enter_context<'a>(_: &'a mut RawJournalWriter<Self>) -> Self::Context<'a> {
+        ()
+    }
+    fn parse_event_meta(meta: u64) -> Option<Self::EventMeta> {
+        CompactDBEventKind::try_from_raw(meta as _)
+    }
+    fn commit_buffered<E>(&mut self, buf: &mut Vec<u8>, ev: E, _: Self::CommitContext)
+    where
+        E: RawJournalAdapterEvent<Self>,
+    {
+        ev.write_buffered(buf, ())
+    }
+    fn decode_apply<'a>(
+        gs: &Self::GlobalState,
+        meta: Self::EventMeta,
+        file: &mut TrackedReader<Self::Spec>,
+        heuristics: &mut JournalHeuristics,
+    ) -> RuntimeResult<()> {
+        match meta {
+            CompactDBEventKind::Insert => read_kv(file, gs),
+            CompactDBEventKind::Update => {
+                heuristics.report_new_redundant_record();
+                read_kv(file, gs)
+            }
+            CompactDBEventKind::Remove => {
+                heuristics.report_new_redundant_record();
+                let klen = u64::from_le_bytes(file.read_block()?);
+                if file.remaining() >= klen {
+                    let mut key = vec![0; klen as usize];
+                    file.tracked_read(&mut key)?;
+                    if let Ok(key) = String::from_utf8(key) {
+                        let _ = gs.data.write().remove(&key);
+                        return Ok(());
+                    }
+                }
+                Err(StorageError::RawJournalDecodeEventCorruptedPayload.into())
+            }
+        }
+    }
+}
+
+fn read_kv(
+    file: &mut TrackedReader<SystemDatabaseV1>,
+    gs: &CompactDB,
+) -> Result<(), crate::engine::fractal::error::Error> {
+    let klen = u64::from_le_bytes(file.read_block()?);
+    let vlen = u64::from_le_bytes(file.read_block()?);
+    if file.remaining() >= klen + vlen {
+        let mut key = vec![0; klen as usize];
+        let mut val = vec![0; vlen as usize];
+        file.tracked_read(&mut key)?;
+        file.tracked_read(&mut val)?;
+        if let (Ok(key), Ok(val)) = (String::from_utf8(key), String::from_utf8(val)) {
+            let _ = gs.data.write().insert(key, val);
+            return Ok(());
+        }
+    }
+    Err(StorageError::RawJournalDecodeEventCorruptedPayload.into())
+}
+
+pub struct Insert<'a>(&'a str, &'a str);
+impl<'a> RawJournalAdapterEvent<CompactDBAdapter> for Insert<'a> {
+    fn md(&self) -> u64 {
+        CompactDBEventKind::Insert.dscr_u64()
+    }
+    fn write_buffered<'b>(
+        self,
+        buf: &mut Vec<u8>,
+        _: <CompactDBAdapter as RawJournalAdapter>::CommitContext,
+    ) {
+        buf.extend(&self.0.len().to_le_bytes());
+        buf.extend(&self.1.len().to_le_bytes());
+        buf.extend(self.0.as_bytes());
+        buf.extend(self.1.as_bytes());
+    }
+}
+
+pub struct Update<'a>(&'a str, &'a str);
+impl<'a> RawJournalAdapterEvent<CompactDBAdapter> for Update<'a> {
+    fn md(&self) -> u64 {
+        CompactDBEventKind::Update.dscr_u64()
+    }
+    fn write_buffered<'b>(
+        self,
+        buf: &mut Vec<u8>,
+        _: <CompactDBAdapter as RawJournalAdapter>::CommitContext,
+    ) {
+        buf.extend(&self.0.len().to_le_bytes());
+        buf.extend(&self.1.len().to_le_bytes());
+        buf.extend(self.0.as_bytes());
+        buf.extend(self.1.as_bytes());
+    }
+}
+
+pub struct Remove<'a>(&'a str);
+impl<'a> RawJournalAdapterEvent<CompactDBAdapter> for Remove<'a> {
+    fn md(&self) -> u64 {
+        CompactDBEventKind::Remove.dscr_u64()
+    }
+    fn write_buffered<'b>(
+        self,
+        buf: &mut Vec<u8>,
+        _: <CompactDBAdapter as RawJournalAdapter>::CommitContext,
+    ) {
+        buf.extend(&self.0.len().to_le_bytes());
+        buf.extend(self.0.as_bytes());
+    }
+}
+
+fn genkv(i: usize) -> (String, String) {
+    (
+        format!("key-{:0>width$}", i, width = 100),
+        format!("val-{:0>width$}", i, width = 100),
+    )
+}
+
+#[test]
+fn server_events_only() {
+    let mut jrnl = jinit("server_events_only_compact").unwrap();
+    RawJournalWriter::close_driver(&mut jrnl).unwrap();
+    drop(jrnl); // net drv: 1
+    let (mut jrnl, stat) = jload(&CompactDB::default(), "server_events_only_compact").unwrap();
+    RawJournalWriter::close_driver(&mut jrnl).unwrap();
+    drop(jrnl); // net drv: 1 + 2 = 3
+    assert!(!stat.compaction_recommended());
+    // we need to create 4 more cycles
+    for _ in 0..4 {
+        let (mut jrnl, stat) = jload(&CompactDB::default(), "server_events_only_compact").unwrap();
+        assert!(!stat.compaction_recommended());
+        RawJournalWriter::close_driver(&mut jrnl).unwrap();
+    }
+    let (_, stat) = jload(&CompactDB::default(), "server_events_only_compact").unwrap();
+    assert!(stat.compaction_recommended());
+}
+
+#[test]
+fn do_not_compact_unique() {
+    /*
+        we create multiple unique events leading to not redundancy
+    */
+    let mut jrnl = jinit("do_not_compact_unique").unwrap();
+    let cdb = CompactDB::default();
+    for (k, v) in (0..100).into_iter().map(genkv) {
+        cdb.insert(&mut jrnl, k, v).unwrap();
+    }
+    RawJournalWriter::close_driver(&mut jrnl).unwrap();
+    drop(jrnl);
+    let (_, stat) = jload(&cdb, "do_not_compact_unique").unwrap();
+    assert!(!stat.compaction_recommended());
+}
+
+#[test]
+fn compact_because_duplicate() {
+    /*
+        we create multiple overlapping events leading to redundancy
+    */
+    let mut jrnl = jinit("do_not_compact_unique").unwrap();
+    let cdb = CompactDB::default();
+    for (i, (k, v)) in (0..=100).into_iter().map(genkv).enumerate() {
+        cdb.insert(&mut jrnl, k.clone(), v.clone()).unwrap();
+        if i % 10 == 0 {
+            cdb.update(&mut jrnl, k, "W".repeat(100)).unwrap();
+        } else if i == 99 {
+            // just ensure that we breach the 10%
+            cdb.remove(&mut jrnl, k).unwrap();
+        }
+    }
+    RawJournalWriter::close_driver(&mut jrnl).unwrap();
+    drop(jrnl);
+    let (_, stat) = jload(&cdb, "do_not_compact_unique").unwrap();
+    assert!(stat.compaction_recommended());
+}
+
+#[test]
+fn compact_because_server_event_exceeded() {
+    let mut jrnl = jinit("compact_because_server_event_exceeded").unwrap();
+    let db = CompactDB::default();
+    for (k, v) in (0..5).into_iter().map(genkv) {
+        db.insert(&mut jrnl, k, v).unwrap();
+    }
+    RawJournalWriter::close_driver(&mut jrnl).unwrap();
+    drop(jrnl); // 1 drv
+    for (k, v) in (5..9).into_iter().map(genkv) {
+        let db = CompactDB::default();
+        let (mut jrnl, stat) = jload(&db, "compact_because_server_event_exceeded").unwrap();
+        assert!(!stat.compaction_recommended());
+        db.insert(&mut jrnl, k, v).unwrap();
+        RawJournalWriter::close_driver(&mut jrnl).unwrap();
+        drop(jrnl);
+    }
+    // net drv events: 1 + 4*2 = 9. net srv events = 5 + 4 = 9
+    let (_, stat) = jload(
+        &CompactDB::default(),
+        "compact_because_server_event_exceeded",
+    )
+    .unwrap();
+    assert!(stat.compaction_recommended());
+}

--- a/server/src/engine/storage/v2/raw/journal/raw/tests/journal_ops.rs
+++ b/server/src/engine/storage/v2/raw/journal/raw/tests/journal_ops.rs
@@ -61,7 +61,7 @@ fn journal_open_close() {
     }
     {
         // second boot
-        let mut j = open_journal::<SimpleDBJournal>(
+        let (mut j, _) = open_journal::<SimpleDBJournal>(
             JOURNAL_NAME,
             &SimpleDB::new(),
             JournalSettings::default(),
@@ -106,7 +106,7 @@ fn journal_open_close() {
     }
     {
         // third boot
-        let mut j = open_journal::<SimpleDBJournal>(
+        let (mut j, _) = open_journal::<SimpleDBJournal>(
             JOURNAL_NAME,
             &SimpleDB::new(),
             JournalSettings::default(),
@@ -191,9 +191,10 @@ fn journal_with_server_single_event() {
     {
         let db = SimpleDB::new();
         // second boot
-        let mut j = open_journal::<SimpleDBJournal>(JOURNAL_NAME, &db, JournalSettings::default())
-            .set_dmsg_fn(|| format!("{:?}", debug_get_trace()))
-            .unwrap();
+        let (mut j, _) =
+            open_journal::<SimpleDBJournal>(JOURNAL_NAME, &db, JournalSettings::default())
+                .set_dmsg_fn(|| format!("{:?}", debug_get_trace()))
+                .unwrap();
         assert_eq!(db.data().len(), 1);
         assert_eq!(db.data()[0], "hello world");
         assert_eq!(
@@ -242,7 +243,7 @@ fn journal_with_server_single_event() {
     {
         // third boot
         let db = SimpleDB::new();
-        let mut j =
+        let (mut j, _) =
             open_journal::<SimpleDBJournal>(JOURNAL_NAME, &db, JournalSettings::default()).unwrap();
         assert_eq!(db.data().len(), 1);
         assert_eq!(db.data()[0], "hello world");
@@ -314,7 +315,7 @@ fn multi_boot() {
     }
     {
         let mut db = SimpleDB::new();
-        let mut j =
+        let (mut j, _) =
             open_journal::<SimpleDBJournal>("multiboot", &db, JournalSettings::default()).unwrap();
         assert_eq!(db.data().as_ref(), vec!["key_a".to_string()]);
         db.clear(&mut j).unwrap();
@@ -323,7 +324,7 @@ fn multi_boot() {
     }
     {
         let db = SimpleDB::new();
-        let mut j =
+        let (mut j, _) =
             open_journal::<SimpleDBJournal>("multiboot", &db, JournalSettings::default()).unwrap();
         assert_eq!(db.data().as_ref(), vec!["myfinkey".to_string()]);
         RawJournalWriter::close_driver(&mut j).unwrap();

--- a/server/src/engine/storage/v2/raw/journal/raw/tests/mod.rs
+++ b/server/src/engine/storage/v2/raw/journal/raw/tests/mod.rs
@@ -24,13 +24,14 @@
  *
 */
 
+mod compaction;
 mod journal_ops;
 mod recovery;
 
 use {
     super::{
-        create_journal, CommitPreference, DriverEvent, DriverEventKind, JournalInitializer,
-        RawJournalAdapter, RawJournalAdapterEvent, RawJournalWriter,
+        create_journal, CommitPreference, DriverEvent, DriverEventKind, JournalHeuristics,
+        JournalInitializer, RawJournalAdapter, RawJournalAdapterEvent, RawJournalWriter,
     },
     crate::engine::{
         error::StorageError,
@@ -169,6 +170,7 @@ impl RawJournalAdapter for SimpleDBJournal {
         gs: &Self::GlobalState,
         meta: Self::EventMeta,
         file: &mut TrackedReader<Self::Spec>,
+        _: &mut JournalHeuristics,
     ) -> RuntimeResult<()> {
         match meta {
             EventMeta::NewKey => {

--- a/server/src/engine/storage/v2/raw/journal/raw/tests/mod.rs
+++ b/server/src/engine/storage/v2/raw/journal/raw/tests/mod.rs
@@ -284,7 +284,7 @@ fn jw_state() {
         let mut jrnl = create_journal::<SimpleDBJournal>("jw_state_test").unwrap();
         jrnl.commit_event(DbEventPush("hello")).unwrap();
         // backup + destroy
-        state_backup = jrnl.close_and_cleanup().unwrap();
+        state_backup = jrnl.cleanup().unwrap();
         assert_eq!(
             super::debug_get_trace(),
             intovec![

--- a/server/src/engine/storage/v2/raw/journal/raw/tests/recovery.rs
+++ b/server/src/engine/storage/v2/raw/journal/raw/tests/recovery.rs
@@ -147,7 +147,7 @@ fn journal_open(
     journal_id: &str,
     db: &SimpleDB,
 ) -> RuntimeResult<RawJournalWriter<SimpleDBJournal>> {
-    open_journal(journal_id, db, JournalSettings::default())
+    open_journal(journal_id, db, JournalSettings::default()).map(|(jw, _)| jw)
 }
 
 #[derive(Debug)]

--- a/server/src/engine/storage/v2/raw/spec.rs
+++ b/server/src/engine/storage/v2/raw/spec.rs
@@ -67,7 +67,7 @@ pub enum FileSpecifier {
     ModelData = 1,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HeaderImplV2;
 impl sdss::sdss_r1::HeaderV1Spec for HeaderImplV2 {
     type FileClass = FileClass;

--- a/server/src/engine/sync/smart.rs
+++ b/server/src/engine/sync/smart.rs
@@ -245,6 +245,11 @@ pub struct RawRC<T> {
     rc_data: NonNull<RawRCData<T>>,
 }
 
+#[cfg(test)]
+unsafe impl<T: Send> Send for RawRC<T> {}
+#[cfg(test)]
+unsafe impl<T: Sync> Sync for RawRC<T> {}
+
 #[derive(Debug)]
 struct RawRCData<T> {
     rc: AtomicUsize,


### PR DESCRIPTION
This PR adds support for compaction (auto-triggered or explicitly invoked) of database files while also fixing a DCL bug with `sysctl alter user`