### PR TITLE
CLI: fix binary syntax has a bug to add one backtick

### DIFF
--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -327,7 +327,7 @@ impl Parameterizer {
             self.i += 1;
             if b == b'`' {
                 self.params
-                    .push(Item::Bin(self.buf[start..self.i].to_vec()));
+                    .push(Item::Bin(self.buf[start..self.i-1].to_vec()));
                 return Ok(());
             }
         }


### PR DESCRIPTION
### How to reproduce bug
```
create space test
create model test.test(id:uint8, v:binary)
insert into test.test(0, ``)
select v from test.test where id=0
```
and the result is `([96])` where it must be `([])`.
### Reason
The closing backtick(ascii:96) was added into query parameter because of wrong range to take.

---
✔️ By submitting this pull request, I agree to the CLA at: https://cla.skytable.io/skytable/skytable
