### PR TITLE
server: Add support for dynamic lists in Skyhash

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,49 @@
+name: Miri
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Install rustup and nightly rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        profile: minimal
+        override: true
+        components: miri
+
+    - name: Cache cargo registry
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-registry-
+    
+    - name: Cache cargo index
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-index-
+    
+    - name: Cache cargo build
+      uses: actions/cache@v3
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-build-
+
+    - name: Run miri audit
+      run: make audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,13 +112,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -199,9 +199,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "bzip2"
@@ -226,13 +226,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.100"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
 ]
 
 [[package]]
@@ -258,7 +257,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -273,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "clipboard-win"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79f4473f5144e20d9aceaf2972478f06ddf687831eafeeb434fbaf0acc4144ad"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
 dependencies = [
  "error-code",
 ]
@@ -374,7 +373,7 @@ dependencies = [
  "bitflags",
  "crossterm_winapi",
  "libc",
- "mio",
+ "mio 0.8.11",
  "parking_lot",
  "signal-hook",
  "signal-hook-mio",
@@ -402,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "deflate64"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ace6c86376be0b6cdcf3fb41882e81d94b31587573d1cfa9d01cd06bba210d"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "deranged"
@@ -423,7 +422,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -445,7 +444,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -456,9 +455,9 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "env_filter"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+checksum = "c6dc8c8ff84895b051f07a0e65f975cf225131742531338752abfb324e4449ff"
 dependencies = [
  "log",
  "regex",
@@ -466,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+checksum = "06676b12debf7bba6903559720abca942d3a66b8acb88815fd2c7c6537e9ade1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -716,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -769,9 +768,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lzma-rs"
@@ -808,6 +807,18 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "wasi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -875,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -890,9 +901,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -911,7 +922,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -931,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
@@ -962,7 +973,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1093,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags",
 ]
@@ -1202,9 +1213,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1215,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1225,22 +1236,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1284,7 +1295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
  "signal-hook",
 ]
 
@@ -1376,8 +1387,8 @@ dependencies = [
 
 [[package]]
 name = "skytable"
-version = "0.8.9"
-source = "git+https://github.com/skytable/client-rust.git?branch=devel#95b6e3395b43e46b23ff20ae896c3fb9351cda1b"
+version = "0.8.10"
+source = "git+https://github.com/skytable/client-rust.git?branch=devel#aa6df69a049c7e9d654a629b7f52b18caf192a53"
 dependencies = [
  "async-trait",
  "bb8",
@@ -1408,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1425,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.67"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1448,22 +1459,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1487,32 +1498,31 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
- "num_cpus",
+ "mio 1.0.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1575,9 +1585,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "rand",
@@ -1586,13 +1596,13 @@ dependencies = [
 
 [[package]]
 name = "uuid-macro-internal"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9881bea7cbe687e36c9ab3b778c36cd0487402e270304e8b1296d5085303c1a2"
+checksum = "ee1cd046f83ea2c4e920d6ee9f7c3537ef928d75dce5d84a87c2c5d6b3999a3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1634,7 +1644,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -1656,7 +1666,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1691,12 +1701,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.5",
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1705,50 +1715,61 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-result",
- "windows-targets 0.52.5",
+ "windows-strings",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1766,7 +1787,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1786,18 +1807,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1808,9 +1829,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1820,9 +1841,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1832,15 +1853,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1850,9 +1871,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1862,9 +1883,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1874,9 +1895,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1886,9 +1907,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zeroize"
@@ -1907,14 +1928,14 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "zip"
-version = "2.1.3"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775a2b471036342aa69bc5a602bc889cb0a06cda00477d0c69566757d5553d39"
+checksum = "b895748a3ebcb69b9d38dcfdf21760859a4b0d0b0015277640c2ef4c69640e6f"
 dependencies = [
  "aes",
  "arbitrary",
@@ -1955,27 +1976,27 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.11+zstd.1.5.6"
+version = "2.0.12+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
+checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,7 +1388,7 @@ dependencies = [
 [[package]]
 name = "skytable"
 version = "0.8.10"
-source = "git+https://github.com/skytable/client-rust.git?branch=devel#c2337cbbd0a50775bd345d987b747c1e4eb7d6f6"
+source = "git+https://github.com/skytable/client-rust.git?branch=devel#64aa9a9a9028183fecd88f6853c1c33b21158ba9"
 dependencies = [
  "async-trait",
  "bb8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,7 +1388,7 @@ dependencies = [
 [[package]]
 name = "skytable"
 version = "0.8.10"
-source = "git+https://github.com/skytable/client-rust.git?branch=devel#aa6df69a049c7e9d654a629b7f52b18caf192a53"
+source = "git+https://github.com/skytable/client-rust.git?branch=devel#c2337cbbd0a50775bd345d987b747c1e4eb7d6f6"
 dependencies = [
  "async-trait",
  "bb8",

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,5 @@ bundle-dbg: .harness
 	@${RUN_HARNESS} bundle-dbg
 deb: .harness
 	@${RUN_HARNESS} deb
+audit: .harness
+	@${RUN_HARNESS} audit

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -9,8 +9,8 @@ build = "build.rs"
 # internal deps
 libsky = { path = "../libsky" }
 # external deps
-env_logger = "0.11.3"
-log = "0.4.21"
-zip = { version = "2.1.3", features = ["deflate"] }
+env_logger = "0.11.4"
+log = "0.4.22"
+zip = { version = "2.1.5", features = ["deflate"] }
 powershell_script = "1.1.0"
-openssl = { version = "0.10.64", features = ["vendored"] }
+openssl = { version = "0.10.66", features = ["vendored"] }

--- a/harness/src/cli.rs
+++ b/harness/src/cli.rs
@@ -47,6 +47,7 @@ pub enum HarnessWhat {
     Test,
     Bundle(BuildMode),
     LinuxPackage(LinuxPackageType),
+    Audit,
 }
 
 impl HarnessWhat {
@@ -54,6 +55,7 @@ impl HarnessWhat {
     const CLI_BUNDLE: &'static str = "bundle";
     const CLI_BUNDLE_DEBUG: &'static str = "bundle-dbg";
     const CLI_DEB: &'static str = "deb";
+    const CLI_AUDIT: &'static str = "audit";
     const CLI_ARG_HELP: &'static str = "--help";
     const CLI_ARG_HELP_SHORT: &'static str = "-h";
     /// Returns the target _harness mode_ from env
@@ -73,6 +75,7 @@ impl HarnessWhat {
             Self::CLI_BUNDLE_DEBUG => HarnessWhat::Bundle(BuildMode::Debug),
             Self::CLI_ARG_HELP_SHORT | Self::CLI_ARG_HELP => display_help(),
             Self::CLI_DEB => HarnessWhat::LinuxPackage(LinuxPackageType::Deb),
+            Self::CLI_AUDIT => HarnessWhat::Audit,
             unknown_arg => return Err(HarnessError::UnknownCommand(unknown_arg.to_string())),
         };
         Ok(ret)
@@ -82,6 +85,7 @@ impl HarnessWhat {
             HarnessWhat::Test => "test suite".to_owned(),
             HarnessWhat::Bundle(mode) => format!("{} bundle", mode.to_string()),
             HarnessWhat::LinuxPackage(pkg) => format!("Linux package {}", pkg.to_string()),
+            HarnessWhat::Audit => "audit".to_owned(),
         }
     }
 }

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -28,6 +28,7 @@
 extern crate log;
 #[macro_use]
 mod util;
+mod audit;
 mod build;
 mod bundle;
 mod cli;
@@ -72,6 +73,7 @@ fn runner() -> HarnessResult<()> {
         HarnessWhat::Test => test::run_test()?,
         HarnessWhat::Bundle(bundle_mode) => bundle::bundle(bundle_mode)?,
         HarnessWhat::LinuxPackage(pkg) => linuxpkg::create_linuxpkg(pkg)?,
+        HarnessWhat::Audit => audit::audit()?,
     }
     info!(
         "Successfully finished running harness for {}",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,16 +16,16 @@ libsky = { path = "../libsky" }
 sky_macros = { path = "../sky-macros" }
 rcrypt = "0.4.0"
 # external deps
-bytes = "1.6.0"
-env_logger = "0.11.3"
-log = "0.4.21"
-openssl = { version = "0.10.64", features = ["vendored"] }
+bytes = "1.6.1"
+env_logger = "0.11.4"
+log = "0.4.22"
+openssl = { version = "0.10.66", features = ["vendored"] }
 crossbeam-epoch = { version = "0.9.18" }
 parking_lot = "0.12.3"
-serde = { version = "1.0.203", features = ["derive"] }
-tokio = { version = "1.38.0", features = ["full"] }
+serde = { version = "1.0.204", features = ["derive"] }
+tokio = { version = "1.39.1", features = ["full"] }
 tokio-openssl = "0.6.4"
-uuid = { version = "1.8.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
+uuid = { version = "1.10.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
 crc = "3.2.1"
 serde_yaml = "0.9.33"
 chrono = "0.4.38"
@@ -35,7 +35,7 @@ chrono = "0.4.38"
 jemallocator = "0.5.4"
 [target.'cfg(target_os = "windows")'.dependencies]
 # external deps
-windows = { version = "0.57.0", features = [
+windows = { version = "0.58.0", features = [
   "Win32_Foundation",
   "Win32_System_IO",
   "Win32_Storage_FileSystem",
@@ -49,7 +49,7 @@ libc = "0.2.155"
 [dev-dependencies]
 # external deps
 rand = "0.8.5"
-tokio = { version = "1.38.0", features = ["test-util"] }
+tokio = { version = "1.39.1", features = ["test-util"] }
 skytable = { git = "https://github.com/skytable/client-rust.git", branch = "devel" }
 
 [features]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -54,7 +54,6 @@ skytable = { git = "https://github.com/skytable/client-rust.git", branch = "deve
 
 [features]
 nightly = []
-persist-suite = []
 
 [package.metadata.deb]
 name = "skytable"

--- a/server/build.rs
+++ b/server/build.rs
@@ -1,3 +1,7 @@
 fn main() -> std::io::Result<()> {
-    libsky::build_scripts::format_all_help_txt("skyd", "help_text", Default::default())
+    libsky::build_scripts::format_all_help_txt("skyd", "help_text", Default::default())?;
+    if std::env::var("CARGO_CFG_MIRI").is_ok() {
+        println!("cargo:rustc-cfg=feature=\"miri\"");
+    }
+    Ok(())
 }

--- a/server/src/engine/core/index/key.rs
+++ b/server/src/engine/core/index/key.rs
@@ -267,7 +267,7 @@ impl fmt::Debug for PrimaryIndexKey {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn gh_issue_test_325_same_type_collapse() {
     assert_ne!(
         PrimaryIndexKey::try_from_dc(Datacell::new_uint_default(1)).unwrap(),
@@ -283,7 +283,7 @@ fn gh_issue_test_325_same_type_collapse() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn check_pk_wrong_type() {
     let data = [
         Datacell::from(false),
@@ -305,7 +305,7 @@ fn check_pk_wrong_type() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn check_pk_eq_hash() {
     let state = test_utils::randomstate();
     let data = [
@@ -326,7 +326,7 @@ fn check_pk_eq_hash() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn check_pk_lit_eq_hash() {
     let state = test_utils::randomstate();
     let data = [
@@ -345,7 +345,7 @@ fn check_pk_lit_eq_hash() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn check_pk_extremes() {
     let state = test_utils::randomstate();
     let d1 = PrimaryIndexKey::try_from_dc(Datacell::new_uint_default(u64::MAX)).unwrap();
@@ -362,7 +362,7 @@ fn check_pk_extremes() {
     assert_eq!(d1.uint().unwrap(), u64::MAX);
 }
 
-#[test]
+#[sky_macros::test]
 fn empty_slice() {
     // bin
     let pk1 = PrimaryIndexKey::try_from_dc(Datacell::from(Lit::new_bin(b""))).unwrap();
@@ -378,7 +378,7 @@ fn empty_slice() {
     drop((pk2, pk2_));
 }
 
-#[test]
+#[sky_macros::test]
 fn ensure_ptr_offsets() {
     let data = String::from("hello").into_boxed_str();
     let __orig = (data.as_ptr(), data.len());
@@ -393,7 +393,7 @@ fn ensure_ptr_offsets() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn queue_ensure_offsets() {
     use crate::engine::sync::queue::Queue;
     let data: Vec<_> = (0..100)

--- a/server/src/engine/core/tests/ddl_model/alt.rs
+++ b/server/src/engine/core/tests/ddl_model/alt.rs
@@ -84,7 +84,7 @@ mod plan {
     /*
         Simple
     */
-    #[test]
+    #[sky_macros::test]
     fn simple_add() {
         super::plan(
             "create model myspace.mymodel(username: string, password: binary)",
@@ -101,7 +101,7 @@ mod plan {
             },
         )
     }
-    #[test]
+    #[sky_macros::test]
     fn simple_remove() {
         super::plan(
             "create model myspace.mymodel(username: string, password: binary, useless_field: uint8)",
@@ -116,7 +116,7 @@ mod plan {
             },
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn simple_update() {
         // FREEDOM! DAMN THE PASSWORD!
         super::plan(
@@ -134,7 +134,7 @@ mod plan {
             },
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn update_need_lock() {
         // FIGHT THE NULL
         super::plan(
@@ -155,7 +155,7 @@ mod plan {
     /*
         Illegal
     */
-    #[test]
+    #[sky_macros::test]
     fn illegal_remove_nx() {
         assert_eq!(
             super::with_plan(
@@ -167,7 +167,7 @@ mod plan {
             QueryError::QExecUnknownField
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn illegal_remove_pk() {
         assert_eq!(
             super::with_plan(
@@ -179,7 +179,7 @@ mod plan {
             QueryError::QExecDdlModelAlterIllegal
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn illegal_add_pk() {
         assert_eq!(
             super::with_plan(
@@ -191,7 +191,7 @@ mod plan {
             QueryError::QExecDdlModelAlterIllegal
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn illegal_add_ex() {
         assert_eq!(
             super::with_plan(
@@ -203,7 +203,7 @@ mod plan {
             QueryError::QExecDdlModelAlterIllegal
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn illegal_update_pk() {
         assert_eq!(
             super::with_plan(
@@ -215,7 +215,7 @@ mod plan {
             QueryError::QExecDdlModelAlterIllegal
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn illegal_update_nx() {
         assert_eq!(
             super::with_plan(
@@ -251,7 +251,7 @@ mod plan {
             }
         }
     }
-    #[test]
+    #[sky_macros::test]
     fn illegal_bool_direct_cast() {
         enumerated_bad_type_casts(
             ["bool"],
@@ -264,7 +264,7 @@ mod plan {
             ],
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn illegal_uint_direct_cast() {
         enumerated_bad_type_casts(
             model::TY_UINT,
@@ -278,7 +278,7 @@ mod plan {
             ],
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn illegal_sint_direct_cast() {
         enumerated_bad_type_casts(
             model::TY_SINT,
@@ -292,7 +292,7 @@ mod plan {
             ],
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn illegal_float_direct_cast() {
         enumerated_bad_type_casts(
             model::TY_FLOAT,
@@ -306,7 +306,7 @@ mod plan {
             ],
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn illegal_binary_direct_cast() {
         enumerated_bad_type_casts(
             [model::TY_BINARY],
@@ -320,7 +320,7 @@ mod plan {
             ],
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn illegal_string_direct_cast() {
         enumerated_bad_type_casts(
             [model::TY_STRING],
@@ -334,7 +334,7 @@ mod plan {
             ],
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn illegal_list_direct_cast() {
         enumerated_bad_type_casts(
             ["list { type: string }"],
@@ -357,7 +357,7 @@ mod exec {
         fractal::test_utils::TestGlobal,
         idx::{STIndex, STIndexSeq},
     };
-    #[test]
+    #[sky_macros::test]
     fn simple_add() {
         let global = TestGlobal::new_with_driver_id("simple_add");
         super::exec_plan(
@@ -387,7 +387,7 @@ mod exec {
         )
         .unwrap();
     }
-    #[test]
+    #[sky_macros::test]
     fn simple_remove() {
         let global = TestGlobal::new_with_driver_id("simple_remove");
         super::exec_plan(
@@ -412,7 +412,7 @@ mod exec {
             }
         ).unwrap();
     }
-    #[test]
+    #[sky_macros::test]
     fn simple_update() {
         let global = TestGlobal::new_with_driver_id("simple_update");
         super::exec_plan(
@@ -430,7 +430,7 @@ mod exec {
         )
         .unwrap();
     }
-    #[test]
+    #[sky_macros::test]
     fn failing_alter_nullable_switch_need_lock() {
         let global = TestGlobal::new_with_driver_id("failing_alter_nullable_switch_need_lock");
         assert_eq!(

--- a/server/src/engine/core/tests/ddl_model/crt.rs
+++ b/server/src/engine/core/tests/ddl_model/crt.rs
@@ -35,7 +35,7 @@ mod validation {
         },
     };
 
-    #[test]
+    #[sky_macros::test]
     fn simple() {
         let model =
             create("create model myspace.mymodel(username: string, password: binary)").unwrap();
@@ -58,7 +58,7 @@ mod validation {
         );
     }
 
-    #[test]
+    #[sky_macros::test]
     fn idiotic_order() {
         let model =
             create("create model myspace.mymodel(password: binary, primary username: string)")
@@ -82,7 +82,7 @@ mod validation {
         );
     }
 
-    #[test]
+    #[sky_macros::test]
     fn duplicate_primary_key() {
         assert_eq!(
             create(
@@ -93,7 +93,7 @@ mod validation {
         );
     }
 
-    #[test]
+    #[sky_macros::test]
     fn duplicate_fields() {
         assert_eq!(
             create("create model myspace.mymodel(primary username: string, username: binary)")
@@ -102,7 +102,7 @@ mod validation {
         );
     }
 
-    #[test]
+    #[sky_macros::test]
     fn illegal_props() {
         assert_eq!(
         create("create model myspace.mymodel(primary username: string, password: binary) with { lol_prop: false }").unwrap_err(),
@@ -110,7 +110,7 @@ mod validation {
     );
     }
 
-    #[test]
+    #[sky_macros::test]
     fn illegal_pk() {
         assert_eq!(
         create(
@@ -144,7 +144,7 @@ mod exec {
 
     const SPACE: &str = "myspace";
 
-    #[test]
+    #[sky_macros::test]
     fn simple() {
         let global = TestGlobal::new_with_driver_id("exec_simple_create");
         exec_create_new_space(

--- a/server/src/engine/core/tests/ddl_model/layer.rs
+++ b/server/src/engine/core/tests/ddl_model/layer.rs
@@ -45,12 +45,12 @@ mod layer_spec_validation {
         crate::engine::{core::model::Layer, error::QueryError},
     };
 
-    #[test]
+    #[sky_macros::test]
     fn string() {
         assert_eq!(layerview("string").unwrap().layers(), [Layer::str()]);
     }
 
-    #[test]
+    #[sky_macros::test]
     fn nested_list() {
         assert_eq!(
             layerview("list { type: list { type: string } }")
@@ -60,7 +60,7 @@ mod layer_spec_validation {
         );
     }
 
-    #[test]
+    #[sky_macros::test]
     fn invalid_list() {
         assert_eq!(
             layerview("list").unwrap_err(),
@@ -68,7 +68,7 @@ mod layer_spec_validation {
         );
     }
 
-    #[test]
+    #[sky_macros::test]
     fn invalid_flat() {
         assert_eq!(
             layerview("string { type: string }").unwrap_err(),
@@ -82,14 +82,14 @@ mod layer_data_validation {
         super::{layerview, layerview_nullable},
         crate::engine::{core::model, data::cell::Datacell},
     };
-    #[test]
+    #[sky_macros::test]
     fn bool() {
         let mut dc = Datacell::new_bool(true);
         let layer = layerview("bool").unwrap();
         assert!(layer.vt_data_fpath(&mut dc));
         assert_vecstreq_exact!(model::layer_traces(), ["fpath", "bool"]);
     }
-    #[test]
+    #[sky_macros::test]
     fn uint() {
         let targets = [
             ("uint8", u8::MAX as u64),
@@ -117,7 +117,7 @@ mod layer_data_validation {
                 }
             });
     }
-    #[test]
+    #[sky_macros::test]
     fn sint() {
         let targets = [
             ("sint8", (i8::MIN as i64, i8::MAX as i64)),
@@ -155,7 +155,7 @@ mod layer_data_validation {
                 }
             });
     }
-    #[test]
+    #[sky_macros::test]
     fn float() {
         // l
         let f32_l = layerview("float32").unwrap();
@@ -180,19 +180,19 @@ mod layer_data_validation {
         assert!(f64_l.vt_data_fpath(&mut f64_dc_max.clone()));
         assert_vecstreq_exact!(model::layer_traces(), ["fpath", "float", "fpath", "float"]);
     }
-    #[test]
+    #[sky_macros::test]
     fn bin() {
         let layer = layerview("binary").unwrap();
         assert!(layer.vt_data_fpath(&mut Datacell::from("hello".as_bytes())));
         assert_vecstreq_exact!(model::layer_traces(), ["fpath", "binary"]);
     }
-    #[test]
+    #[sky_macros::test]
     fn str() {
         let layer = layerview("string").unwrap();
         assert!(layer.vt_data_fpath(&mut Datacell::from("hello")));
         assert_vecstreq_exact!(model::layer_traces(), ["fpath", "string"]);
     }
-    #[test]
+    #[sky_macros::test]
     fn list_simple() {
         let layer = layerview("list { type: string }").unwrap();
         let mut dc = Datacell::new_list(vec![
@@ -206,7 +206,7 @@ mod layer_data_validation {
             ["list", "string", "string", "string"]
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn list_nested_l1() {
         let layer = layerview("list { type: list { type: string } }").unwrap();
         let mut dc = Datacell::new_list(vec![
@@ -225,13 +225,13 @@ mod layer_data_validation {
             ]
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn nullval_fpath() {
         let layer = layerview_nullable("string", true).unwrap();
         assert!(layer.vt_data_fpath(&mut Datacell::null()));
         assert_vecstreq_exact!(model::layer_traces(), ["fpath", "bool"]);
     }
-    #[test]
+    #[sky_macros::test]
     fn nullval_nested_but_fpath() {
         let layer = layerview_nullable("list { type: string }", true).unwrap();
         assert!(layer.vt_data_fpath(&mut Datacell::null()));

--- a/server/src/engine/core/tests/ddl_space/alter.rs
+++ b/server/src/engine/core/tests/ddl_space/alter.rs
@@ -31,7 +31,7 @@ use crate::engine::{
     fractal::test_utils::TestGlobal,
 };
 
-#[test]
+#[sky_macros::test]
 fn alter_add_prop_env_var() {
     let global = TestGlobal::new_with_driver_id("alter_add_prop_env_var");
     super::exec_create_alter(
@@ -51,7 +51,7 @@ fn alter_add_prop_env_var() {
     .unwrap();
 }
 
-#[test]
+#[sky_macros::test]
 fn alter_update_prop_env_var() {
     let global = TestGlobal::new_with_driver_id("alter_update_prop_env_var");
     let uuid = super::exec_create(
@@ -81,7 +81,7 @@ fn alter_update_prop_env_var() {
     .unwrap();
 }
 
-#[test]
+#[sky_macros::test]
 fn alter_remove_prop_env_var() {
     let global = TestGlobal::new_with_driver_id("alter_remove_prop_env_var");
     let uuid = super::exec_create(
@@ -111,7 +111,7 @@ fn alter_remove_prop_env_var() {
     .unwrap();
 }
 
-#[test]
+#[sky_macros::test]
 fn alter_nx() {
     let global = TestGlobal::new_with_driver_id("alter_nx");
     assert_eq!(
@@ -125,7 +125,7 @@ fn alter_nx() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn alter_remove_all_env() {
     let global = TestGlobal::new_with_driver_id("alter_remove_all_env");
     let uuid = super::exec_create(

--- a/server/src/engine/core/tests/ddl_space/create.rs
+++ b/server/src/engine/core/tests/ddl_space/create.rs
@@ -31,7 +31,7 @@ use crate::engine::{
     fractal::test_utils::TestGlobal,
 };
 
-#[test]
+#[sky_macros::test]
 fn exec_create_space_simple() {
     let global = TestGlobal::new_with_driver_id("exec_create_space_simple");
     super::exec_create(&global, "create space myspace", |spc| {
@@ -40,7 +40,7 @@ fn exec_create_space_simple() {
     .unwrap();
 }
 
-#[test]
+#[sky_macros::test]
 fn exec_create_space_with_env() {
     let global = TestGlobal::new_with_driver_id("exec_create_space_with_env");
     super::exec_create(
@@ -67,7 +67,7 @@ fn exec_create_space_with_env() {
     .unwrap();
 }
 
-#[test]
+#[sky_macros::test]
 fn exec_create_space_with_bad_env_type() {
     let global = TestGlobal::new_with_driver_id("exec_create_space_with_bad_env_type");
     assert_eq!(
@@ -76,7 +76,7 @@ fn exec_create_space_with_bad_env_type() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn exec_create_space_with_random_property() {
     let global = TestGlobal::new_with_driver_id("exec_create_space_with_random_property");
     assert_eq!(

--- a/server/src/engine/core/tests/dml/delete.rs
+++ b/server/src/engine/core/tests/dml/delete.rs
@@ -26,7 +26,7 @@
 
 use crate::engine::{error::QueryError, fractal::test_utils::TestGlobal};
 
-#[test]
+#[sky_macros::test]
 fn simple_delete() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_delete_simple_delete");
     super::exec_delete(
@@ -39,7 +39,7 @@ fn simple_delete() {
     .unwrap();
 }
 
-#[test]
+#[sky_macros::test]
 fn delete_nonexisting() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_delete_delete_nonexisting");
     assert_eq!(

--- a/server/src/engine/core/tests/dml/insert.rs
+++ b/server/src/engine/core/tests/dml/insert.rs
@@ -29,7 +29,7 @@ use crate::engine::{data::cell::Datacell, error::QueryError, fractal::test_utils
 #[derive(sky_macros::Wrapper, Debug)]
 struct Tuple(Vec<(Box<str>, Datacell)>);
 
-#[test]
+#[sky_macros::test]
 fn insert_simple() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_insert_simple");
     super::exec_insert(
@@ -44,7 +44,7 @@ fn insert_simple() {
     .unwrap();
 }
 
-#[test]
+#[sky_macros::test]
 fn insert_with_null() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_insert_with_null");
     super::exec_insert(
@@ -67,7 +67,7 @@ fn insert_with_null() {
     ).unwrap();
 }
 
-#[test]
+#[sky_macros::test]
 fn insert_duplicate() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_insert_duplicate");
     super::exec_insert(

--- a/server/src/engine/core/tests/dml/select.rs
+++ b/server/src/engine/core/tests/dml/select.rs
@@ -29,7 +29,7 @@ use {
     std::collections::HashMap,
 };
 
-#[test]
+#[sky_macros::test]
 fn simple_select_wildcard() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_select_simple_select_wildcard");
     assert_eq!(
@@ -44,7 +44,7 @@ fn simple_select_wildcard() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn simple_select_specified_same_order() {
     let global = TestGlobal::new_with_driver_id_instant_update(
         "dml_select_simple_select_specified_same_order",
@@ -61,7 +61,7 @@ fn simple_select_specified_same_order() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn simple_select_specified_reversed_order() {
     let global = TestGlobal::new_with_driver_id_instant_update(
         "dml_select_simple_select_specified_reversed_order",
@@ -78,7 +78,7 @@ fn simple_select_specified_reversed_order() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn select_null() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_select_select_null");
     assert_eq!(
@@ -93,7 +93,7 @@ fn select_null() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn select_nonexisting() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_select_select_nonexisting");
     assert_eq!(
@@ -112,7 +112,7 @@ fn select_nonexisting() {
     select all
 */
 
-#[test]
+#[sky_macros::test]
 fn select_all_wildcard() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_select_select_all_wildcard");
     let ret = super::exec_select_all(
@@ -139,7 +139,7 @@ fn select_all_wildcard() {
     assert_eq!(ret.get("orwell").unwrap(), &intovec!["1984"]);
 }
 
-#[test]
+#[sky_macros::test]
 fn select_all_onefield() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_select_select_all_onefield");
     let ret = super::exec_select_all(

--- a/server/src/engine/core/tests/dml/update.rs
+++ b/server/src/engine/core/tests/dml/update.rs
@@ -28,7 +28,7 @@ use crate::engine::{
     core::dml, data::cell::Datacell, error::QueryError, fractal::test_utils::TestGlobal,
 };
 
-#[test]
+#[sky_macros::test]
 fn simple() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_update_simple");
     assert_eq!(
@@ -47,7 +47,7 @@ fn simple() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn with_null() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_update_with_null");
     assert_eq!(
@@ -64,7 +64,7 @@ fn with_null() {
     assert_eq!(dml::update_flow_trace(), ["sametag;orignull"]);
 }
 
-#[test]
+#[sky_macros::test]
 fn with_list() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_update_with_list");
     assert_eq!(
@@ -84,7 +84,7 @@ fn with_list() {
     assert_eq!(dml::update_flow_trace(), ["list;sametag"]);
 }
 
-#[test]
+#[sky_macros::test]
 fn fail_operation_on_null() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_update_fail_operation_on_null");
     assert_eq!(
@@ -104,7 +104,7 @@ fn fail_operation_on_null() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn fail_unknown_fields() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_update_fail_unknown_fields");
     assert_eq!(
@@ -130,7 +130,7 @@ fn fail_unknown_fields() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn fail_typedef_violation() {
     let global = TestGlobal::new_with_driver_id_instant_update("dml_update_fail_typedef_violation");
     assert_eq!(

--- a/server/src/engine/data/cell.rs
+++ b/server/src/engine/data/cell.rs
@@ -552,7 +552,7 @@ impl<'a> Clone for VirtualDatacell<'a> {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn vdc_check() {
     let dc = Lit::new_str("hello, world");
     assert_eq!(
@@ -561,7 +561,7 @@ fn vdc_check() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn empty_slice() {
     let dc1 = Datacell::from(Lit::new_bin(b""));
     assert_eq!(dc1, Datacell::new_bin(b"".to_vec().into_boxed_slice()));

--- a/server/src/engine/data/lit.rs
+++ b/server/src/engine/data/lit.rs
@@ -359,7 +359,7 @@ impl<'a> ToString for Lit<'a> {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn stk_variants() {
     let stk1 = [
         Lit::new_bool(true),
@@ -373,7 +373,7 @@ fn stk_variants() {
     assert_eq!(stk1, stk2);
 }
 
-#[test]
+#[sky_macros::test]
 fn hp_variants() {
     let hp1 = [
         Lit::new_string("hello".into()),
@@ -383,14 +383,14 @@ fn hp_variants() {
     assert_eq!(hp1, hp2);
 }
 
-#[test]
+#[sky_macros::test]
 fn lt_link() {
     let l = Lit::new_string("hello".into());
     let l_ir = l.as_ir();
     assert_eq!(l, l_ir);
 }
 
-#[test]
+#[sky_macros::test]
 fn token_array_lt_test() {
     let tokens = vec![Lit::new_string("hello".to_string()), Lit::new_str("hi")];
     #[derive(Debug)]

--- a/server/src/engine/data/tests/md_dict_tests.rs
+++ b/server/src/engine/data/tests/md_dict_tests.rs
@@ -29,7 +29,7 @@ use crate::engine::data::{
     dict::{self, DictEntryGeneric, DictGeneric},
 };
 
-#[test]
+#[sky_macros::test]
 fn t_simple_flatten() {
     let generic_dict: DictGeneric = into_dict! {
         "a_valid_key" => DictEntryGeneric::Data(100u64.into()),
@@ -42,7 +42,7 @@ fn t_simple_flatten() {
     assert_eq!(ret, expected);
 }
 
-#[test]
+#[sky_macros::test]
 fn t_simple_patch() {
     let mut current: DictGeneric = into_dict! {
         "a" => Datacell::new_uint_default(2),
@@ -62,7 +62,7 @@ fn t_simple_patch() {
     assert_eq!(current, expected);
 }
 
-#[test]
+#[sky_macros::test]
 fn t_bad_patch() {
     let mut current: DictGeneric = into_dict! {
         "a" => Datacell::new_uint_default(2),
@@ -79,7 +79,7 @@ fn t_bad_patch() {
     assert_eq!(current, backup);
 }
 
-#[test]
+#[sky_macros::test]
 fn patch_null_out_dict() {
     let mut current: DictGeneric = into_dict! {
         "a" => Datacell::new_uint_default(2),

--- a/server/src/engine/fractal/error.rs
+++ b/server/src/engine/fractal/error.rs
@@ -154,39 +154,51 @@ impl IntoError for Error {
 
 pub trait ErrorContext<T> {
     // no inherit
+    #[allow(dead_code)]
     /// set the origin (do not inherit parent or local)
     fn set_origin(self, origin: Subsystem) -> Result<T, Error>;
     /// set the dmsg (do not inherit parent or local)
     fn set_dmsg(self, dmsg: impl Into<Dmsg>) -> Result<T, Error>;
+    #[allow(dead_code)]
     fn set_dmsg_fn<F, M>(self, d: F) -> Result<T, Error>
     where
         F: Fn() -> M,
         M: Into<Dmsg>,
         Self: Sized;
+    #[allow(dead_code)]
     /// set the origin and dmsg (do not inherit)
     fn set_ctx(self, origin: Subsystem, dmsg: impl Into<Dmsg>) -> Result<T, Error>;
     // inherit parent
+    #[allow(dead_code)]
     /// set the origin (inherit rest from parent)
     fn ip_set_origin(self, origin: Subsystem) -> Result<T, Error>;
+    #[allow(dead_code)]
     /// set the dmsg (inherit rest from origin)
     fn ip_set_dmsg(self, dmsg: impl Into<Dmsg>) -> Result<T, Error>;
     // inherit local
+    #[allow(dead_code)]
     /// set the origin (inherit rest from local)
     fn il_set_origin(self, origin: Subsystem) -> Result<T, Error>;
+    #[allow(dead_code)]
     /// set the dmsg (inherit rest from local)
     fn il_set_dmsg(self, dmsg: impl Into<Dmsg>) -> Result<T, Error>;
+    #[allow(dead_code)]
     /// inherit everything from local (assuming this has no context)
     fn inherit_local(self) -> Result<T, Error>;
     // inherit any
+    #[allow(dead_code)]
     /// set the origin (inherit rest from either parent, then local)
     fn inherit_set_origin(self, origin: Subsystem) -> Result<T, Error>;
     /// set the dmsg (inherit rest from either parent, then local)
     fn inherit_set_dmsg(self, dmsg: impl Into<Dmsg>) -> Result<T, Error>;
     // orphan
+    #[allow(dead_code)]
     /// orphan the entire context (if any)
     fn orphan(self) -> Result<T, Error>;
+    #[allow(dead_code)]
     /// orphan the origin (if any)
     fn orphan_origin(self) -> Result<T, Error>;
+    #[allow(dead_code)]
     /// orphan the dmsg (if any)
     fn orphan_dmsg(self) -> Result<T, Error>;
 }

--- a/server/src/engine/idx/meta/mod.rs
+++ b/server/src/engine/idx/meta/mod.rs
@@ -47,6 +47,7 @@ pub trait Comparable<K: ?Sized>: Hash {
 }
 
 pub trait ComparableUpgradeable<K>: Comparable<K> {
+    #[allow(dead_code)]
     fn upgrade(&self) -> K;
 }
 

--- a/server/src/engine/idx/mod.rs
+++ b/server/src/engine/idx/mod.rs
@@ -53,6 +53,7 @@ pub type IndexST<K, V, S = std::collections::hash_map::RandomState> =
 
 /// Any type implementing this trait can be used as a key inside memory engine structures
 pub trait AsKey: Hash + Eq + 'static {
+    #[allow(dead_code)]
     /// Read the key
     fn read_key(&self) -> &Self;
 }
@@ -65,6 +66,7 @@ impl<T: Hash + Eq + ?Sized + 'static> AsKey for T {
 
 /// If your T can be cloned/copied and implements [`AsKey`], then this trait will automatically be implemented
 pub trait AsKeyClone: AsKey + Clone {
+    #[allow(dead_code)]
     /// Read the key and return a clone
     fn read_key_clone(&self) -> Self;
 }
@@ -87,6 +89,7 @@ impl<T: ?Sized + 'static> AsValue for T {
 
 /// Any type implementing this trait can be used as a value inside memory engine structures
 pub trait AsValueClone: AsValue + Clone {
+    #[allow(dead_code)]
     /// Read the value and return a clone
     fn read_value_clone(&self) -> Self;
 }
@@ -114,6 +117,7 @@ pub trait IndexBaseSpec: Sized {
     /// Initialize an empty instance of the index
     fn idx_init() -> Self;
     /// Initialize a pre-loaded instance of the index
+    #[allow(dead_code)]
     fn idx_init_with(s: Self) -> Self;
     /// Init the idx with the given cap
     ///
@@ -126,6 +130,7 @@ pub trait IndexBaseSpec: Sized {
     }
     #[cfg(debug_assertions)]
     /// Returns a reference to the index metrics
+    #[allow(dead_code)]
     fn idx_metrics(&self) -> &Self::Metrics;
 }
 
@@ -151,11 +156,14 @@ pub trait MTIndex<E, K, V>: IndexBaseSpec {
         V: 'v,
         Self: 't;
     fn mt_iter_kv<'t, 'g, 'v>(&'t self, g: &'g Guard) -> Self::IterKV<'t, 'g, 'v>;
+    #[allow(dead_code)]
     fn mt_iter_key<'t, 'g, 'v>(&'t self, g: &'g Guard) -> Self::IterKey<'t, 'g, 'v>;
+    #[allow(dead_code)]
     fn mt_iter_val<'t, 'g, 'v>(&'t self, g: &'g Guard) -> Self::IterVal<'t, 'g, 'v>;
     /// Returns the length of the index
     fn mt_len(&self) -> usize;
     /// Attempts to compact the backing storage
+    #[allow(dead_code)]
     fn mt_compact(&self) {}
     /// Clears all the entries in the MTIndex
     fn mt_clear(&self, g: &Guard);
@@ -169,6 +177,7 @@ pub trait MTIndex<E, K, V>: IndexBaseSpec {
     fn mt_upsert(&self, e: E, g: &Guard) -> bool
     where
         V: AsValue;
+    #[allow(dead_code)]
     // read
     fn mt_contains<Q>(&self, key: &Q, g: &Guard) -> bool
     where
@@ -184,17 +193,20 @@ pub trait MTIndex<E, K, V>: IndexBaseSpec {
         Q: ?Sized + Comparable<K>,
         't: 'v,
         'g: 't + 'v;
+    #[allow(dead_code)]
     /// Returns a clone of the value corresponding to the key, if it exists
     fn mt_get_cloned<Q>(&self, key: &Q, g: &Guard) -> Option<V>
     where
         Q: ?Sized + Comparable<K>,
         V: AsValueClone;
     // update
+    #[allow(dead_code)]
     /// Returns true if the entry is updated
     fn mt_update(&self, e: E, g: &Guard) -> bool
     where
         K: AsKeyClone,
         V: AsValue;
+    #[allow(dead_code)]
     /// Updates the entry and returns the old value, if it exists
     fn mt_update_return<'t, 'g, 'v>(&'t self, e: E, g: &'g Guard) -> Option<&'v V>
     where
@@ -207,6 +219,7 @@ pub trait MTIndex<E, K, V>: IndexBaseSpec {
     fn mt_delete<Q>(&self, key: &Q, g: &Guard) -> bool
     where
         Q: ?Sized + Comparable<K>;
+    #[allow(dead_code)]
     /// Removes the entry and returns it, if it exists
     fn mt_delete_return<'t, 'g, 'v, Q>(&'t self, key: &Q, g: &'g Guard) -> Option<&'v V>
     where
@@ -252,8 +265,10 @@ pub trait STIndex<K: ?Sized, V>: IndexBaseSpec {
         V: 'a;
     /// returns the length of the idx
     fn st_len(&self) -> usize;
+    #[allow(dead_code)]
     /// Attempts to compact the backing storage
     fn st_compact(&mut self) {}
+    #[allow(dead_code)]
     /// Clears all the entries in the STIndex
     fn st_clear(&mut self);
     // write
@@ -278,6 +293,7 @@ pub trait STIndex<K: ?Sized, V>: IndexBaseSpec {
     where
         K: AsKey + Borrow<Q>,
         Q: ?Sized + AsKey;
+    #[allow(dead_code)]
     /// Returns a clone of the value corresponding to the key, if it exists
     fn st_get_cloned<Q>(&self, key: &Q) -> Option<V>
     where
@@ -295,6 +311,7 @@ pub trait STIndex<K: ?Sized, V>: IndexBaseSpec {
         K: AsKey + Borrow<Q>,
         V: AsValue,
         Q: ?Sized + AsKey;
+    #[allow(dead_code)]
     /// Updates the entry and returns the old value, if it exists
     fn st_update_return<Q>(&mut self, key: &Q, val: V) -> Option<V>
     where
@@ -312,15 +329,19 @@ pub trait STIndex<K: ?Sized, V>: IndexBaseSpec {
     where
         K: AsKey + Borrow<Q>,
         Q: ?Sized + AsKey;
+    #[allow(dead_code)]
     fn st_delete_if<Q>(&mut self, key: &Q, iff: impl Fn(&V) -> bool) -> Option<bool>
     where
         K: AsKey + Borrow<Q>,
         Q: ?Sized + AsKey;
     // iter
+    #[allow(dead_code)]
     /// Returns an iterator over a tuple of keys and values
     fn st_iter_kv<'a>(&'a self) -> Self::IterKV<'a>;
+    #[allow(dead_code)]
     /// Returns an iterator over the keys
     fn st_iter_key<'a>(&'a self) -> Self::IterKey<'a>;
+    #[allow(dead_code)]
     /// Returns an iterator over the values
     fn st_iter_value<'a>(&'a self) -> Self::IterValue<'a>;
 }
@@ -356,10 +377,13 @@ pub trait STIndexSeq<K, V>: STIndex<K, V> {
     fn stseq_ord_kv<'a>(&'a self) -> Self::IterOrdKV<'a>;
     /// Returns an ordered iterator over the keys
     fn stseq_ord_key<'a>(&'a self) -> Self::IterOrdKey<'a>;
+    #[allow(dead_code)]
     /// Returns an ordered iterator over the values
     fn stseq_ord_value<'a>(&'a self) -> Self::IterOrdValue<'a>;
     // owned
     fn stseq_owned_kv(self) -> Self::OwnedIterKV;
+    #[allow(dead_code)]
     fn stseq_owned_keys(self) -> Self::OwnedIterKeys;
+    #[allow(dead_code)]
     fn stseq_owned_values(self) -> Self::OwnedIterValues;
 }

--- a/server/src/engine/idx/mtchm/meta.rs
+++ b/server/src/engine/idx/mtchm/meta.rs
@@ -78,6 +78,7 @@ pub trait TreeElement: Clone + 'static {
     type VEx2;
     fn key(&self) -> &Self::Key;
     fn val(&self) -> &Self::Value;
+    #[allow(dead_code)]
     fn new(k: Self::IKey, v: Self::IValue, vex1: Self::VEx1, vex2: Self::VEx2) -> Self;
 }
 

--- a/server/src/engine/idx/mtchm/tests.rs
+++ b/server/src/engine/idx/mtchm/tests.rs
@@ -91,19 +91,19 @@ impl Default for LolState {
 type ChmU8 = Chm<u8, u8>;
 
 // empty
-#[test]
+#[sky_macros::test]
 fn drop_empty() {
     let idx = ChmU8::idx_init();
     drop(idx);
 }
 
-#[test]
+#[sky_macros::test]
 fn get_empty() {
     let idx = ChmU8::idx_init();
     assert!(idx.mt_get(&10, &cpin()).is_none());
 }
 
-#[test]
+#[sky_macros::test]
 fn update_empty() {
     let idx = ChmU8::idx_init();
     assert!(!idx.mt_update((10, 20), &cpin()));
@@ -251,7 +251,7 @@ fn _verify_eq<C: Config>(
     });
 }
 
-#[test]
+#[sky_macros::test]
 fn multispam_insert() {
     let idx = Arc::new(ChmCopy::default());
     let token = ControlToken::new();
@@ -260,7 +260,7 @@ fn multispam_insert() {
     modify_and_verify_integrity(&token, &idx, &data, _action_put, _verify_eq);
 }
 
-#[test]
+#[sky_macros::test]
 fn multispam_update() {
     let idx = Arc::new(ChmCopy::default());
     let token = ControlToken::new();
@@ -302,7 +302,7 @@ fn multispam_update() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn multispam_delete() {
     let idx = Arc::new(ChmCopy::default());
     let token = ControlToken::new();
@@ -332,7 +332,7 @@ fn multispam_delete() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn multispam_lol() {
     let idx = Arc::new(super::RawTree::<StringTup, super::meta::Config2B<LolState>>::new());
     let token = ControlToken::new();

--- a/server/src/engine/idx/stord/iter.rs
+++ b/server/src/engine/idx/stord/iter.rs
@@ -58,6 +58,7 @@ unsafe_marker_impl!(unsafe impl for IndexSTSeqDllIterUnordKV<'a, K, V>);
 
 impl<'a, K: 'a, V: 'a> IndexSTSeqDllIterUnordKV<'a, K, V> {
     #[inline(always)]
+    #[allow(dead_code)]
     pub(super) fn new<S>(
         m: &'a StdMap<IndexSTSeqDllKeyptr<K>, NonNull<IndexSTSeqDllNode<K, V>>, S>,
     ) -> Self {
@@ -111,6 +112,7 @@ unsafe_marker_impl!(unsafe impl for IndexSTSeqDllIterUnordKey<'a, K, V>);
 
 impl<'a, K: 'a, V: 'a> IndexSTSeqDllIterUnordKey<'a, K, V> {
     #[inline(always)]
+    #[allow(dead_code)]
     pub(super) fn new<S>(
         m: &'a StdMap<IndexSTSeqDllKeyptr<K>, NonNull<IndexSTSeqDllNode<K, V>>, S>,
     ) -> Self {
@@ -162,6 +164,7 @@ unsafe_marker_impl!(unsafe impl for IndexSTSeqDllIterUnordValue<'a, K, V>);
 
 impl<'a, K: 'a, V: 'a> IndexSTSeqDllIterUnordValue<'a, K, V> {
     #[inline(always)]
+    #[allow(dead_code)]
     pub(super) fn new<S>(
         m: &'a StdMap<IndexSTSeqDllKeyptr<K>, NonNull<IndexSTSeqDllNode<K, V>>, S>,
     ) -> Self {
@@ -568,6 +571,7 @@ pub struct IndexSTSeqDllIterOrdValue<'a, K: 'a, V: 'a> {
     i: IndexSTSeqDllIterOrdBase<'a, K, V, IndexSTSeqDllIterOrdConfigValue>,
 }
 impl<'a, K: 'a, V: 'a> IndexSTSeqDllIterOrdValue<'a, K, V> {
+    #[allow(dead_code)]
     pub(super) fn new<C: Config<K, V>>(arg: &'a IndexSTSeqDll<K, V, C>) -> Self {
         Self {
             i: IndexSTSeqDllIterOrdBase::new(arg),

--- a/server/src/engine/idx/tests.rs
+++ b/server/src/engine/idx/tests.rs
@@ -54,41 +54,41 @@ mod idx_st_seq_dll {
     fn s(s: &str) -> String {
         s.to_owned()
     }
-    #[test]
+    #[sky_macros::test]
     fn empty_drop() {
         let idx = Index::idx_init();
         assert_eq!(idx.idx_metrics().raw_f(), 0);
         drop(idx);
     }
-    #[test]
+    #[sky_macros::test]
     fn spam_read_nx() {
         let idx = IndexSTSeqLib::<usize, String>::idx_init();
         for int in SPAM_CNT..SPAM_CNT * 2 {
             assert!(idx.st_get(&int).is_none());
         }
     }
-    #[test]
+    #[sky_macros::test]
     fn spam_insert_ex() {
         let mut idx = mkidx();
         for int in 0..SPAM_CNT {
             assert!(!idx.st_insert(int, (int + 2).to_string()));
         }
     }
-    #[test]
+    #[sky_macros::test]
     fn spam_update_nx() {
         let mut idx = IndexSTSeqLib::<usize, String>::idx_init();
         for int in 0..SPAM_CNT {
             assert!(!idx.st_update(&int, (int + 2).to_string()));
         }
     }
-    #[test]
+    #[sky_macros::test]
     fn spam_delete_nx() {
         let mut idx = IndexSTSeqLib::<usize, String>::idx_init();
         for int in 0..SPAM_CNT {
             assert!(!idx.st_delete(&int));
         }
     }
-    #[test]
+    #[sky_macros::test]
     fn simple_crud() {
         let mut idx = Index::idx_init();
         assert!(idx.st_insert(s("hello"), s("world")));
@@ -98,7 +98,7 @@ mod idx_st_seq_dll {
         assert_eq!(idx.st_delete_return("hello").unwrap(), "world2");
         assert_eq!(idx.idx_metrics().raw_f(), 1);
     }
-    #[test]
+    #[sky_macros::test]
     fn spam_crud() {
         let mut idx = IndexSTSeqLib::idx_init();
         for int in 0..SPAM_CNT {
@@ -110,7 +110,7 @@ mod idx_st_seq_dll {
         }
         assert_eq!(idx.idx_metrics().raw_f(), 1);
     }
-    #[test]
+    #[sky_macros::test]
     fn spam_read() {
         let mut idx = IndexSTSeqLib::idx_init();
         for int in 0..SPAM_CNT {
@@ -120,7 +120,7 @@ mod idx_st_seq_dll {
         }
         assert_eq!(idx.idx_metrics().raw_f(), 0);
     }
-    #[test]
+    #[sky_macros::test]
     fn spam_update() {
         let mut idx = mkidx();
         for int in 0..SPAM_CNT {
@@ -131,7 +131,7 @@ mod idx_st_seq_dll {
         }
         assert_eq!(idx.idx_metrics().raw_f(), 0);
     }
-    #[test]
+    #[sky_macros::test]
     fn spam_delete() {
         let mut idx = mkidx();
         for int in 0..SPAM_CNT {
@@ -140,7 +140,7 @@ mod idx_st_seq_dll {
         }
         assert_eq!(idx.idx_metrics().raw_f(), SPAM_CNT);
     }
-    #[test]
+    #[sky_macros::test]
     fn compact() {
         let mut idx = mkidx();
         assert_eq!(idx.idx_metrics().raw_f(), 0);
@@ -154,7 +154,7 @@ mod idx_st_seq_dll {
         assert_eq!(idx.idx_metrics().raw_f(), 0);
     }
     // pointless testing random iterators
-    #[test]
+    #[sky_macros::test]
     fn iter_ord() {
         let idx1 = mkidx();
         let idx2: Vec<(usize, String)> =
@@ -167,7 +167,7 @@ mod idx_st_seq_dll {
                 assert_eq!((i + 1).to_string(), v);
             });
     }
-    #[test]
+    #[sky_macros::test]
     fn iter_ord_rev() {
         let idx1 = mkidx();
         let idx2: Vec<(usize, String)> = idx1

--- a/server/src/engine/mem/fixed_vec.rs
+++ b/server/src/engine/mem/fixed_vec.rs
@@ -189,13 +189,13 @@ impl<T: fmt::Debug, const CAP: usize> fmt::Debug for FixedVec<T, CAP> {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn empty() {
     let x = FixedVec::<String, 100>::allocate();
     drop(x);
 }
 
-#[test]
+#[sky_macros::test]
 fn push_clear() {
     let mut x: FixedVec<_, 100> = FixedVec::allocate();
     for v in 0..50 {
@@ -211,7 +211,7 @@ fn push_clear() {
     assert_eq!(x.len(), 50);
 }
 
-#[test]
+#[sky_macros::test]
 fn clear_range() {
     let mut x: FixedVec<_, 100> = FixedVec::allocate();
     for v in 0..100 {

--- a/server/src/engine/mem/numbuf.rs
+++ b/server/src/engine/mem/numbuf.rs
@@ -131,42 +131,42 @@ mod tests {
         let mut buf = super::IntegerRepr::new();
         assert_eq!(buf.as_str(v), v.to_string());
     }
-    #[test]
+    #[sky_macros::test]
     fn u8() {
         ibufeq(u8::MIN);
         ibufeq(u8::MAX);
     }
-    #[test]
+    #[sky_macros::test]
     fn i8() {
         ibufeq(i8::MIN);
         ibufeq(i8::MAX);
     }
-    #[test]
+    #[sky_macros::test]
     fn u16() {
         ibufeq(u16::MIN);
         ibufeq(u16::MAX);
     }
-    #[test]
+    #[sky_macros::test]
     fn i16() {
         ibufeq(i16::MIN);
         ibufeq(i16::MAX);
     }
-    #[test]
+    #[sky_macros::test]
     fn u32() {
         ibufeq(u32::MIN);
         ibufeq(u32::MAX);
     }
-    #[test]
+    #[sky_macros::test]
     fn i32() {
         ibufeq(i32::MIN);
         ibufeq(i32::MAX);
     }
-    #[test]
+    #[sky_macros::test]
     fn u64() {
         ibufeq(u64::MIN);
         ibufeq(u64::MAX);
     }
-    #[test]
+    #[sky_macros::test]
     fn i64() {
         ibufeq(i64::MIN);
         ibufeq(i64::MAX);

--- a/server/src/engine/mem/tests/mod.rs
+++ b/server/src/engine/mem/tests/mod.rs
@@ -31,7 +31,7 @@ mod word;
 mod vinline {
     use super::VInline;
     const CAP: usize = 8;
-    #[test]
+    #[sky_macros::test]
     fn drop_empty() {
         let vi = VInline::<CAP, String>::new();
         drop(vi);
@@ -64,17 +64,17 @@ mod vinline {
     fn mkvi_str(upto: usize) -> VInline<CAP, String> {
         cmkvi(upto, |v| v.to_string())
     }
-    #[test]
+    #[sky_macros::test]
     fn push_on_stack() {
         let vi = mkvi(CAP);
         assert!(vi.on_stack());
     }
-    #[test]
+    #[sky_macros::test]
     fn push_on_heap() {
         let vi = mkvi(CAP + 1);
         assert_eq!(vi.capacity(), CAP * 2);
     }
-    #[test]
+    #[sky_macros::test]
     fn remove_on_stack() {
         let mut vi = mkvi(CAP);
         assert_eq!(vi.remove(6), 6);
@@ -82,7 +82,7 @@ mod vinline {
         assert_eq!(vi.capacity(), CAP);
         assert_eq!(vi.as_ref(), [0, 1, 2, 3, 4, 5, 7]);
     }
-    #[test]
+    #[sky_macros::test]
     fn remove_on_heap() {
         let mut vi = mkvi(CAP + 1);
         assert_eq!(vi.remove(6), 6);
@@ -90,14 +90,14 @@ mod vinline {
         assert_eq!(vi.capacity(), CAP * 2);
         assert_eq!(vi.as_ref(), [0, 1, 2, 3, 4, 5, 7, 8]);
     }
-    #[test]
+    #[sky_macros::test]
     fn optimize_capacity_none_on_stack() {
         let mut vi = mkvi(CAP);
         vi.optimize_capacity();
         assert_eq!(vi.capacity(), CAP);
         assert!(vi.on_stack());
     }
-    #[test]
+    #[sky_macros::test]
     fn optimize_capacity_none_on_heap() {
         let mut vi = mkvi(CAP + 1);
         assert_eq!(vi.capacity(), CAP * 2);
@@ -106,14 +106,14 @@ mod vinline {
         vi.optimize_capacity();
         assert_eq!(vi.capacity(), CAP * 2);
     }
-    #[test]
+    #[sky_macros::test]
     fn optimize_capacity_on_heap() {
         let mut vi = mkvi(CAP + 1);
         assert_eq!(vi.capacity(), CAP * 2);
         vi.optimize_capacity();
         assert_eq!(vi.capacity(), CAP + 1);
     }
-    #[test]
+    #[sky_macros::test]
     fn optimize_capacity_mv_stack() {
         let mut vi = mkvi(CAP + 1);
         assert_eq!(vi.capacity(), CAP * 2);
@@ -122,33 +122,33 @@ mod vinline {
         assert_eq!(vi.capacity(), CAP);
         assert!(vi.on_stack());
     }
-    #[test]
+    #[sky_macros::test]
     fn clear_stack() {
         let mut vi = mkvi(CAP);
         vi.clear();
         assert_eq!(vi.capacity(), CAP);
         assert_eq!(vi.len(), 0);
     }
-    #[test]
+    #[sky_macros::test]
     fn clear_heap() {
         let mut vi = mkvi(CAP + 1);
         vi.clear();
         assert_eq!(vi.capacity(), CAP * 2);
         assert_eq!(vi.len(), 0);
     }
-    #[test]
+    #[sky_macros::test]
     fn clone_stack() {
         let v1 = mkvi(CAP);
         let v2 = v1.clone();
         assert_eq!(v1, v2);
     }
-    #[test]
+    #[sky_macros::test]
     fn clone_heap() {
         let v1 = mkvi(CAP + 1);
         let v2 = v1.clone();
         assert_eq!(v1, v2);
     }
-    #[test]
+    #[sky_macros::test]
     fn into_iter_stack() {
         let v1 = mkvi_str(CAP);
         let v: Vec<String> = v1.into_iter().collect();
@@ -156,7 +156,7 @@ mod vinline {
             .zip(v)
             .for_each(|(x, y)| assert_eq!(x.to_string(), y));
     }
-    #[test]
+    #[sky_macros::test]
     fn into_iter_stack_partial() {
         let v1 = mkvi_str(CAP);
         let v: Vec<String> = v1.into_iter().take(CAP / 2).collect();
@@ -164,7 +164,7 @@ mod vinline {
             .zip(v)
             .for_each(|(x, y)| assert_eq!(x.to_string(), y));
     }
-    #[test]
+    #[sky_macros::test]
     fn into_iter_heap() {
         let v1 = mkvi_str(CAP + 2);
         let v: Vec<String> = v1.into_iter().collect();
@@ -172,7 +172,7 @@ mod vinline {
             .zip(v)
             .for_each(|(x, y)| assert_eq!(x.to_string(), y));
     }
-    #[test]
+    #[sky_macros::test]
     fn into_iter_heap_partial() {
         let v1 = mkvi_str(CAP + 2);
         let v: Vec<String> = v1.into_iter().take(CAP / 2).collect();
@@ -180,7 +180,7 @@ mod vinline {
             .zip(v)
             .for_each(|(x, y)| assert_eq!(x.to_string(), y));
     }
-    #[test]
+    #[sky_macros::test]
     fn into_iter_rev_stack() {
         let v1 = mkvi_str(CAP);
         let v: Vec<String> = v1.into_iter().rev().collect();
@@ -189,7 +189,7 @@ mod vinline {
             .zip(v)
             .for_each(|(x, y)| assert_eq!(x.to_string(), y));
     }
-    #[test]
+    #[sky_macros::test]
     fn into_iter_rev_stack_partial() {
         let v1 = mkvi_str(CAP);
         let v: Vec<String> = v1.into_iter().rev().take(CAP / 2).collect();
@@ -198,7 +198,7 @@ mod vinline {
             .zip(v.into_iter())
             .for_each(|(x, y)| assert_eq!(x.to_string(), y));
     }
-    #[test]
+    #[sky_macros::test]
     fn into_iter_rev_heap() {
         let v1 = mkvi_str(CAP + 2);
         let v: Vec<String> = v1.into_iter().rev().collect();
@@ -207,7 +207,7 @@ mod vinline {
             .zip(v)
             .for_each(|(x, y)| assert_eq!(x.to_string(), y));
     }
-    #[test]
+    #[sky_macros::test]
     fn into_iter_rev_heap_partial() {
         let v1 = mkvi_str(CAP + 2);
         let v: Vec<String> = v1.into_iter().rev().take(CAP / 2).collect();
@@ -220,12 +220,12 @@ mod vinline {
 mod uarray {
     use super::UArray;
     const CAP: usize = 8;
-    #[test]
+    #[sky_macros::test]
     fn empty() {
         let a = UArray::<CAP, u8>::new();
         drop(a);
     }
-    #[test]
+    #[sky_macros::test]
     fn push_okay() {
         let mut a = UArray::<CAP, u8>::new();
         a.push(1);
@@ -233,7 +233,7 @@ mod uarray {
         a.push(3);
         a.push(4);
     }
-    #[test]
+    #[sky_macros::test]
     #[should_panic(expected = "stack,capof")]
     fn push_panic() {
         let mut a = UArray::<CAP, u8>::new();
@@ -247,24 +247,24 @@ mod uarray {
         a.push(8);
         a.push(9);
     }
-    #[test]
+    #[sky_macros::test]
     fn slice() {
         let a: UArray<CAP, _> = (1u8..=8).collect();
         assert_eq!(a.as_slice(), [1, 2, 3, 4, 5, 6, 7, 8]);
     }
-    #[test]
+    #[sky_macros::test]
     fn slice_mut() {
         let mut a: UArray<CAP, _> = (0u8..8).collect();
         a.iter_mut().for_each(|v| *v += 1);
         assert_eq!(a.as_slice(), [1, 2, 3, 4, 5, 6, 7, 8])
     }
-    #[test]
+    #[sky_macros::test]
     fn into_iter_empty() {
         let a: UArray<CAP, u8> = UArray::new();
         let r: Vec<u8> = a.into_iter().collect();
         assert!(r.is_empty());
     }
-    #[test]
+    #[sky_macros::test]
     fn into_iter() {
         let a: UArray<CAP, _> = (0u8..8).collect();
         let r: Vec<u8> = a.into_iter().collect();
@@ -272,7 +272,7 @@ mod uarray {
             .zip(r.into_iter())
             .for_each(|(x, y)| assert_eq!(x, y));
     }
-    #[test]
+    #[sky_macros::test]
     fn into_iter_partial() {
         let a: UArray<CAP, String> = (0u8..8).map(|v| ToString::to_string(&v)).collect();
         let r: Vec<String> = a.into_iter().take(4).collect();
@@ -280,13 +280,13 @@ mod uarray {
             .zip(r.into_iter())
             .for_each(|(x, y)| assert_eq!(x.to_string(), y));
     }
-    #[test]
+    #[sky_macros::test]
     fn clone() {
         let a: UArray<CAP, u8> = (0u8..CAP as _).collect();
         let b = a.clone();
         assert_eq!(a, b);
     }
-    #[test]
+    #[sky_macros::test]
     fn into_iter_rev() {
         let a: UArray<CAP, String> = (0u8..8).map(|v| v.to_string()).collect();
         let r: Vec<String> = a.into_iter().rev().collect();
@@ -295,7 +295,7 @@ mod uarray {
             .zip(r.into_iter())
             .for_each(|(x, y)| assert_eq!(x.to_string(), y));
     }
-    #[test]
+    #[sky_macros::test]
     fn into_iter_rev_partial() {
         let a: UArray<CAP, String> = (0u8..8).map(|v| v.to_string()).collect();
         let r: Vec<String> = a.into_iter().rev().take(4).collect();
@@ -304,13 +304,13 @@ mod uarray {
             .zip(r.into_iter())
             .for_each(|(x, y)| assert_eq!(x.to_string(), y));
     }
-    #[test]
+    #[sky_macros::test]
     fn pop_array() {
         let mut a: UArray<CAP, String> = (0u8..8).map(|v| v.to_string()).collect();
         assert_eq!(a.pop().unwrap(), "7");
         assert_eq!(a.len(), CAP - 1);
     }
-    #[test]
+    #[sky_macros::test]
     fn clear_array() {
         let mut a: UArray<CAP, String> = (0u8..8).map(|v| v.to_string()).collect();
         a.clear();

--- a/server/src/engine/mem/tests/scanner.rs
+++ b/server/src/engine/mem/tests/scanner.rs
@@ -34,7 +34,7 @@ fn s(b: &[u8]) -> BufferedScanner {
     lf separated
 */
 
-#[test]
+#[sky_macros::test]
 fn read_u64_lf_separated() {
     let mut s = s(b"18446744073709551615\n");
     assert_eq!(
@@ -45,7 +45,7 @@ fn read_u64_lf_separated() {
     assert_eq!(s.cursor(), s.buffer_len());
 }
 
-#[test]
+#[sky_macros::test]
 fn read_u64_lf_separated_missing() {
     let mut s = s(b"18446744073709551615");
     assert!(s
@@ -54,7 +54,7 @@ fn read_u64_lf_separated_missing() {
     assert_eq!(s.cursor(), 0);
 }
 
-#[test]
+#[sky_macros::test]
 fn read_u64_lf_separated_invalid() {
     let mut scn = s(b"1844674407370955161A\n");
     assert!(scn
@@ -68,7 +68,7 @@ fn read_u64_lf_separated_invalid() {
     assert_eq!(scn.cursor(), 0);
 }
 
-#[test]
+#[sky_macros::test]
 fn read_u64_lf_separated_zero() {
     let mut s = s(b"0\n");
     assert_eq!(
@@ -79,7 +79,7 @@ fn read_u64_lf_separated_zero() {
     assert_eq!(s.cursor(), s.buffer_len());
 }
 
-#[test]
+#[sky_macros::test]
 fn read_u64_lf_overflow() {
     let mut s = s(b"184467440737095516155\n");
     assert!(s
@@ -92,7 +92,7 @@ fn read_u64_lf_overflow() {
     lf separated allow unbuffered
 */
 
-#[test]
+#[sky_macros::test]
 fn incomplete_read_u64_okay() {
     let mut scn = s(b"18446744073709551615\n");
     assert_eq!(
@@ -102,7 +102,7 @@ fn incomplete_read_u64_okay() {
     assert_eq!(scn.cursor(), scn.buffer_len());
 }
 
-#[test]
+#[sky_macros::test]
 fn incomplete_read_u64_missing_lf() {
     let mut scn = s(b"18446744073709551615");
     assert_eq!(
@@ -112,7 +112,7 @@ fn incomplete_read_u64_missing_lf() {
     assert_eq!(scn.cursor(), 0);
 }
 
-#[test]
+#[sky_macros::test]
 fn incomplete_read_u64_lf_error() {
     let mut scn = s(b"1844674407370955161A\n");
     assert_eq!(
@@ -128,7 +128,7 @@ fn incomplete_read_u64_lf_error() {
     assert_eq!(scn.cursor(), 0);
 }
 
-#[test]
+#[sky_macros::test]
 fn incomplete_read_u64_lf_zero() {
     let mut scn = s(b"0\n");
     assert_eq!(
@@ -137,7 +137,7 @@ fn incomplete_read_u64_lf_zero() {
     )
 }
 
-#[test]
+#[sky_macros::test]
 fn incomplete_read_u64_lf_overflow() {
     let mut s = s(b"184467440737095516155\n");
     assert_eq!(
@@ -159,7 +159,7 @@ fn concat(a: impl ToString, b: impl ToString) -> Vec<u8> {
     s.into_bytes()
 }
 
-#[test]
+#[sky_macros::test]
 fn read_i64_lf_separated_okay() {
     let buf = concat(i64::MAX, "\n");
     let mut scn = s(&buf);
@@ -177,7 +177,7 @@ fn read_i64_lf_separated_okay() {
     assert_eq!(scn.cursor(), scn.buffer_len());
 }
 
-#[test]
+#[sky_macros::test]
 fn read_i64_lf_separated_missing() {
     let buf = concat(i64::MAX, "");
     let mut scn = s(&buf);
@@ -195,7 +195,7 @@ fn read_i64_lf_separated_missing() {
     assert_eq!(scn.cursor(), scn.buffer_len());
 }
 
-#[test]
+#[sky_macros::test]
 fn read_i64_lf_separated_invalid() {
     let buf = concat(i64::MAX, "A\n");
     let mut scn = s(&buf);
@@ -210,7 +210,7 @@ fn read_i64_lf_separated_invalid() {
     assert_eq!(scn.cursor(), 0);
 }
 
-#[test]
+#[sky_macros::test]
 fn read_i64_lf_overflow() {
     let buf = concat(u64::MAX, "\n");
     let mut scn = s(&buf);
@@ -221,7 +221,7 @@ fn read_i64_lf_overflow() {
     assert_eq!(scn.cursor(), scn.buffer_len() - 1);
 }
 
-#[test]
+#[sky_macros::test]
 fn read_i64_lf_underflow() {
     let buf = concat(i64::MIN, "1\n");
     let mut scn = s(&buf);
@@ -232,7 +232,7 @@ fn read_i64_lf_underflow() {
     assert_eq!(scn.cursor(), scn.buffer_len() - 1);
 }
 
-#[test]
+#[sky_macros::test]
 fn rounding() {
     let mut scanner = s(b"123");
     for i in 1..=u8::MAX {

--- a/server/src/engine/mem/tests/word.rs
+++ b/server/src/engine/mem/tests/word.rs
@@ -101,12 +101,12 @@ where
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn dwordnn_all() {
     check_primitives::<NativeDword>(|_| {}, |_| {});
 }
 
-#[test]
+#[sky_macros::test]
 fn dwordqn_all() {
     check_primitives::<SpecialPaddedWord>(
         |minword| {
@@ -120,17 +120,17 @@ fn dwordqn_all() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn twordnnn_all() {
     check_primitives::<NativeTword>(|_| {}, |_| {});
 }
 
-#[test]
+#[sky_macros::test]
 fn qwordnnn_all() {
     check_primitives::<NativeQword>(|_| {}, |_| {});
 }
 
-#[test]
+#[sky_macros::test]
 fn dwordqn_promotions() {
     let x = SpecialPaddedWord::store(u64::MAX);
     let y: NativeTword = x.dwordqn_promote();
@@ -154,7 +154,7 @@ fn eval_special_case(x: SpecialPaddedWord, qw: u64, nw: usize) {
     assert_eq!(z.dwordqn_load_qw_nw(), (qw, nw));
 }
 
-#[test]
+#[sky_macros::test]
 fn dwordqn_special_case_ldpk() {
     let hello = "hello, world";
     eval_special_case(

--- a/server/src/engine/mem/word.rs
+++ b/server/src/engine/mem/word.rs
@@ -88,6 +88,7 @@ pub trait DwordNN: Sized {
 }
 
 pub trait DwordQN: Sized {
+    #[allow(dead_code)]
     const DWORDQN_FROM_UPPER: bool = size_of::<Self>() > size_of::<(u64, usize)>();
     fn dwordqn_store_qw_nw(a: u64, b: usize) -> Self;
     fn dwordqn_load_qw_nw(&self) -> (u64, usize);
@@ -163,6 +164,7 @@ impl DwordQN for SpecialPaddedWord {
 */
 
 pub trait TwordNNN: Sized {
+    #[allow(dead_code)]
     const TWORDNNN_FROM_UPPER: bool = size_of::<Self>() > size_of::<[usize; 3]>();
     fn twordnnn_store_native_full(a: usize, b: usize, c: usize) -> Self;
     fn twordnnn_load_native_full(&self) -> [usize; 3];
@@ -225,6 +227,7 @@ impl TwordNNN for NativeTword {
 */
 
 pub trait QwordNNNN: Sized {
+    #[allow(dead_code)]
     const QWORDNNNN_FROM_UPPER: bool = size_of::<Self>() > size_of::<[usize; 4]>();
     fn qwordnnnn_store_native_full(a: usize, b: usize, c: usize, d: usize) -> Self;
     #[allow(dead_code)]

--- a/server/src/engine/mem/word.rs
+++ b/server/src/engine/mem/word.rs
@@ -167,6 +167,7 @@ pub trait TwordNNN: Sized {
     fn twordnnn_store_native_full(a: usize, b: usize, c: usize) -> Self;
     fn twordnnn_load_native_full(&self) -> [usize; 3];
     // promotions
+    #[allow(dead_code)]
     fn tword_promote<W: TwordNNN>(&self) -> W {
         let [a, b, c] = self.twordnnn_load_native_full();
         <W as TwordNNN>::twordnnn_store_native_full(a, b, c)
@@ -226,6 +227,7 @@ impl TwordNNN for NativeTword {
 pub trait QwordNNNN: Sized {
     const QWORDNNNN_FROM_UPPER: bool = size_of::<Self>() > size_of::<[usize; 4]>();
     fn qwordnnnn_store_native_full(a: usize, b: usize, c: usize, d: usize) -> Self;
+    #[allow(dead_code)]
     fn qwordnnnn_store_qw_qw(a: u64, b: u64) -> Self {
         #[cfg(target_pointer_width = "32")]
         {
@@ -238,6 +240,7 @@ pub trait QwordNNNN: Sized {
             Self::qwordnnnn_store_native_full(a as usize, b as usize, 0, 0)
         }
     }
+    #[allow(dead_code)]
     fn qwordnnnn_store_qw_nw_nw(a: u64, b: usize, c: usize) -> Self {
         #[cfg(target_pointer_width = "32")]
         {
@@ -250,6 +253,7 @@ pub trait QwordNNNN: Sized {
         }
     }
     fn qwordnnnn_load_native_full(&self) -> [usize; 4];
+    #[allow(dead_code)]
     fn qwordnnnn_load_qw_qw(&self) -> [u64; 2] {
         let [a, b, c, d] = self.qwordnnnn_load_native_full();
         #[cfg(target_pointer_width = "32")]
@@ -262,6 +266,7 @@ pub trait QwordNNNN: Sized {
             [a as u64, b as u64]
         }
     }
+    #[allow(dead_code)]
     fn qwordnnnn_load_qw_nw_nw(&self) -> (u64, usize, usize) {
         let [a, b, c, d] = self.qwordnnnn_load_native_full();
         #[cfg(target_pointer_width = "32")]

--- a/server/src/engine/net/protocol/tests.rs
+++ b/server/src/engine/net/protocol/tests.rs
@@ -61,7 +61,7 @@ const STATIC_HANDSHAKE_WITH_AUTH: CHandshakeStatic = CHandshakeStatic::new(
     handshake with no state changes
 */
 
-#[test]
+#[sky_macros::test]
 fn handshake_with_multiple_errors() {
     for (bad_hs, error) in [
         // all incorrect
@@ -97,7 +97,7 @@ fn handshake_with_multiple_errors() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn parse_staged_with_auth() {
     for i in 0..FULL_HANDSHAKE_WITH_AUTH.len() {
         let buf = &FULL_HANDSHAKE_WITH_AUTH[..i + 1];
@@ -176,7 +176,7 @@ fn run_state_changes_return_rounds(src: &[u8], expected_final_handshake: CHandsh
     rounds
 }
 
-#[test]
+#[sky_macros::test]
 fn parse_auth_with_state_updates() {
     let rounds = run_state_changes_return_rounds(
         &FULL_HANDSHAKE_WITH_AUTH,
@@ -201,7 +201,7 @@ fn scan_hs(hs: impl AsRef<[u8]>, f: impl Fn(HandshakeResult)) {
     f(hs)
 }
 
-#[test]
+#[sky_macros::test]
 fn hs_bad_packet_illegal_username_length() {
     scan_hs(b"H\0\0\0\0\0A\n8\nsayanpass1234", |hs_result| {
         assert_eq!(
@@ -211,7 +211,7 @@ fn hs_bad_packet_illegal_username_length() {
     })
 }
 
-#[test]
+#[sky_macros::test]
 fn hs_bad_packet_illegal_password_length() {
     scan_hs(b"H\0\0\0\0\05\nA\nsayanpass1234", |hs_result| {
         assert_eq!(
@@ -221,7 +221,7 @@ fn hs_bad_packet_illegal_password_length() {
     })
 }
 
-#[test]
+#[sky_macros::test]
 fn hs_bad_packet_illegal_pwd_uname_length() {
     scan_hs(b"H\0\0\0\0\0A\nA\nsayanpass1234", |hs_result| {
         assert_eq!(
@@ -231,7 +231,7 @@ fn hs_bad_packet_illegal_pwd_uname_length() {
     })
 }
 
-#[test]
+#[sky_macros::test]
 fn hs_bad_packet_first_byte() {
     scan_hs(HS_BAD_PACKET, |hs_result| {
         assert_eq!(
@@ -241,7 +241,7 @@ fn hs_bad_packet_first_byte() {
     })
 }
 
-#[test]
+#[sky_macros::test]
 fn hs_bad_version_hs() {
     scan_hs(HS_BAD_VERSION_HS, |hs_result| {
         assert_eq!(
@@ -251,7 +251,7 @@ fn hs_bad_version_hs() {
     })
 }
 
-#[test]
+#[sky_macros::test]
 fn hs_bad_version_proto() {
     scan_hs(HS_BAD_VERSION_PROTO, |hs_result| {
         assert_eq!(
@@ -261,7 +261,7 @@ fn hs_bad_version_proto() {
     })
 }
 
-#[test]
+#[sky_macros::test]
 fn hs_bad_exchange_mode() {
     scan_hs(HS_BAD_MODE_XCHG, |hs_result| {
         assert_eq!(
@@ -271,7 +271,7 @@ fn hs_bad_exchange_mode() {
     })
 }
 
-#[test]
+#[sky_macros::test]
 fn hs_bad_query_mode() {
     scan_hs(HS_BAD_MODE_QUERY, |hs_result| {
         assert_eq!(
@@ -281,7 +281,7 @@ fn hs_bad_query_mode() {
     })
 }
 
-#[test]
+#[sky_macros::test]
 fn hs_bad_auth_mode() {
     scan_hs(HS_BAD_MODE_AUTH, |hs_result| {
         assert_eq!(hs_result, HandshakeResult::Error(ProtocolError::RejectAuth))
@@ -321,7 +321,7 @@ fn iterate_exchange_payload_from_zero(
     corner cases
 */
 
-#[test]
+#[sky_macros::test]
 fn zero_sized_packet() {
     for payload in [
         "S0\n",    // zero packet
@@ -359,7 +359,7 @@ fn zero_sized_packet() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn invalid_first_byte() {
     for payload in ["A1\n\n", "B7\n5\nsayan"] {
         iterate_exchange_payload(payload, 1, |size, result| {
@@ -439,7 +439,7 @@ impl EQuery {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn ext_query() {
     let ext_query = EQuery::new("create space myspace".to_owned(), &["sayan", "pass", ""]);
     let query_starts_at = ext_query.payload[ext_query.variable_range.clone()]
@@ -484,7 +484,7 @@ const fn nth_position_value(mut real: usize, mut pos: usize) -> usize {
     real
 }
 
-#[test]
+#[sky_macros::test]
 fn simple_query() {
     for query in [
         // small query without params
@@ -612,7 +612,7 @@ fn get_pipeline_from_result(pipeline: ExchangeResult) -> Vec<SQuery> {
     pipeline
 }
 
-#[test]
+#[sky_macros::test]
 fn full_pipe_scan() {
     let pipeline_buffer = pipe([
         EPipeQuery::new_string("create space myspace", &[]),
@@ -668,7 +668,7 @@ impl EPipe {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn pipeline() {
     for pipe in [
         EPipe::new([
@@ -803,7 +803,7 @@ fn run_staged(full_payload: &[u8], f: impl Fn(ExchangeResult)) {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn staged_simple_query() {
     for eq in [
         EQuery::new(
@@ -826,7 +826,7 @@ fn staged_simple_query() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn staged_pipeline() {
     for epipe in [
         EPipe::new([

--- a/server/src/engine/ql/ast/mod.rs
+++ b/server/src/engine/ql/ast/mod.rs
@@ -357,8 +357,6 @@ pub trait QueryData<'a> {
     /// ## Safety
     /// The current token must match the signature of a lit
     unsafe fn read_data_type(&mut self, tok: &'a Token) -> Datacell;
-    /// Returns true if the data source has enough data
-    fn nonzero(&self) -> bool;
 }
 
 #[derive(Debug)]
@@ -382,9 +380,5 @@ impl<'a> QueryData<'a> for InplaceData {
     #[inline(always)]
     unsafe fn read_data_type(&mut self, tok: &'a Token) -> Datacell {
         Datacell::from(<Self as QueryData>::read_lit(self, tok))
-    }
-    #[inline(always)]
-    fn nonzero(&self) -> bool {
-        true
     }
 }

--- a/server/src/engine/ql/dml/ins.rs
+++ b/server/src/engine/ql/dml/ins.rs
@@ -212,6 +212,23 @@ pub(super) fn parse_data_tuple_syntax<'a, Qd: QueryData<'a>>(
                 data.push(l.into());
             }
             Token![null] => data.push(Datacell::null()),
+            Token::DCList(dcl) => unsafe {
+                /*
+                    UNSAFE(@ohsayan): nasty nasty stuff here because technically nothing here is guaranteeing that no
+                    two threads will be doing this in parallel. But the important bit is that two thrads are NEVER used
+                    to decode one token stream so doing crazy things to just enforce statical guarantee for a property
+                    we already know is guaranteed is inherently pointless. Hence, what we do is: swap the pointers!
+
+                    TODO(@ohsayan): BUT I MUST EMPHASIZE FOR GOODNESS SAKE IS THAT THIS IS JUST VERY AWFUL. IT'S PLAIN BUTCHERY
+                    OF BORROWCK'S RULES AND WE *MUST* DO SOMETHING TO `ast::State` to make this semantically better.
+
+                    But the way `State` works in a way does implicitly guarantee that this isn't easily breakable, but yes
+                    transmuting lifetimes are the way to completely break this.
+
+                    SCARY STUFF!
+                */
+                data.push(Datacell::new_list(core::mem::take(&mut *dcl.get())))
+            },
             Token![@] if state.cursor_signature_match_fn_arity0_rounded() => match unsafe {
                 // UNSAFE(@ohsayan): Just verified at guard
                 handle_func_sub(state)

--- a/server/src/engine/ql/lex/mod.rs
+++ b/server/src/engine/ql/lex/mod.rs
@@ -642,7 +642,7 @@ mod scan_param {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn try_this_list() {
     use crate::engine::data::cell::Datacell;
     let params = format!(

--- a/server/src/engine/ql/lex/mod.rs
+++ b/server/src/engine/ql/lex/mod.rs
@@ -632,7 +632,7 @@ mod scan_param {
             }
         }
         if pending_count == 0 && lx.l.no_error() {
-            lx.l.tokens.push(Token::DCList(current_l));
+            lx.l.tokens.push(Token::dc_list(current_l));
         } else {
             lx.l.set_error(QueryError::LexInvalidInput)
         }
@@ -652,7 +652,7 @@ fn try_this_list() {
     let tokens = sec_lex.lex().unwrap();
     assert_eq!(
         tokens[0],
-        Token::DCList(vec![
+        Token::dc_list(vec![
             Datacell::null(),
             Datacell::new_bool(true),
             Datacell::new_uint_default(1234),

--- a/server/src/engine/ql/lex/mod.rs
+++ b/server/src/engine/ql/lex/mod.rs
@@ -25,9 +25,12 @@
 */
 
 mod raw;
-#[cfg(test)]
-pub use insecure_impl::InsecureLexer;
 pub use raw::{Ident, Keyword, KeywordMisc, KeywordStmt, Symbol, Token};
+#[cfg(test)]
+pub use {
+    insecure_impl::InsecureLexer,
+    scan_param::{PROTO_PARAM_SYM_LIST_CLOSE, PROTO_PARAM_SYM_LIST_OPEN},
+};
 
 use {
     crate::engine::{

--- a/server/src/engine/ql/lex/raw.rs
+++ b/server/src/engine/ql/lex/raw.rs
@@ -590,7 +590,7 @@ impl KeywordStmt {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn blocking_capybara() {
     assert!(KeywordStmt::Truncate.is_blocking());
     assert!(!KeywordStmt::Insert.is_blocking());

--- a/server/src/engine/ql/lex/raw.rs
+++ b/server/src/engine/ql/lex/raw.rs
@@ -130,18 +130,6 @@ pub enum Token<'a> {
     DCList(UnsafeCell<Vec<Datacell>>),
 }
 
-impl<'a> Drop for Token<'a> {
-    fn drop(&mut self) {
-        match self {
-            Self::DCList(dcl) => unsafe {
-                // UNSAFE(@ohsayan): we're cleaning up the value. so all good!
-                core::ptr::drop_in_place(dcl)
-            },
-            _ => {}
-        }
-    }
-}
-
 impl<'a> PartialEq for Token<'a> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {

--- a/server/src/engine/ql/lex/raw.rs
+++ b/server/src/engine/ql/lex/raw.rs
@@ -25,7 +25,7 @@
 */
 
 use {
-    crate::engine::data::lit::Lit,
+    crate::engine::data::{cell::Datacell, lit::Lit},
     core::{borrow::Borrow, fmt, ops::Deref, str},
 };
 
@@ -117,7 +117,8 @@ impl<'a> Borrow<[u8]> for Ident<'a> {
     token
 */
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq)]
+#[cfg_attr(test, derive(Clone))]
 pub enum Token<'a> {
     Symbol(Symbol),
     Keyword(Keyword),
@@ -126,6 +127,7 @@ pub enum Token<'a> {
     /// A comma that can be ignored (used for fuzzing)
     IgnorableComma,
     Lit(Lit<'a>), // literal
+    DCList(Vec<Datacell>),
 }
 
 impl<'a> Token<'a> {
@@ -147,6 +149,9 @@ impl<'a> ToString for Token<'a> {
             Self::Keyword(k) => k.to_string(),
             Self::Ident(id) => id.to_string(),
             Self::Lit(l) => l.to_string(),
+            Self::DCList(dc_lst) => {
+                format!("{dc_lst:?}")
+            }
             #[cfg(test)]
             Self::IgnorableComma => "[IGNORE_COMMA]".to_owned(),
         }

--- a/server/src/engine/ql/tests/dcl.rs
+++ b/server/src/engine/ql/tests/dcl.rs
@@ -30,14 +30,14 @@ use crate::engine::ql::{
     tests::lex_insecure,
 };
 
-#[test]
+#[sky_macros::test]
 fn report_status_simple() {
     let query = lex_insecure(b"sysctl report status").unwrap();
     let q = ast::parse_ast_node_full::<dcl::SysctlCommand>(&query[1..]).unwrap();
     assert_eq!(q, SysctlCommand::ReportStatus)
 }
 
-#[test]
+#[sky_macros::test]
 fn create_user_simple() {
     let query = lex_insecure(b"sysctl create user sayan with { password: 'mypass123' }").unwrap();
     let q = ast::parse_ast_node_full::<dcl::SysctlCommand>(&query[1..]).unwrap();
@@ -50,7 +50,7 @@ fn create_user_simple() {
     )
 }
 
-#[test]
+#[sky_macros::test]
 fn alter_user_simple() {
     let query = lex_insecure(b"sysctl alter user sayan with { password: 'mypass123' }").unwrap();
     let q = ast::parse_ast_node_full::<dcl::SysctlCommand>(&query[1..]).unwrap();
@@ -63,7 +63,7 @@ fn alter_user_simple() {
     )
 }
 
-#[test]
+#[sky_macros::test]
 fn delete_user_simple() {
     let query = lex_insecure(b"sysctl drop user monster").unwrap();
     let q = ast::parse_ast_node_full::<dcl::SysctlCommand>(&query[1..]).unwrap();

--- a/server/src/engine/ql/tests/dml_tests.rs
+++ b/server/src/engine/ql/tests/dml_tests.rs
@@ -29,7 +29,7 @@ mod list_parse {
     use super::*;
     use crate::engine::ql::{ast::parse_ast_node_full, dml::ins::List};
 
-    #[test]
+    #[sky_macros::test]
     fn list_mini() {
         let tok = lex_insecure(
             b"
@@ -40,7 +40,7 @@ mod list_parse {
         let r = parse_ast_node_full::<List>(&tok[1..]).unwrap();
         assert_eq!(r, vec![])
     }
-    #[test]
+    #[sky_macros::test]
     fn list() {
         let tok = lex_insecure(
             b"
@@ -51,7 +51,7 @@ mod list_parse {
         let r = parse_ast_node_full::<List>(&tok[1..]).unwrap();
         assert_eq!(r.as_slice(), into_array![1, 2, 3, 4])
     }
-    #[test]
+    #[sky_macros::test]
     fn list_pro() {
         let tok = lex_insecure(
             b"
@@ -75,7 +75,7 @@ mod list_parse {
             ]
         )
     }
-    #[test]
+    #[sky_macros::test]
     fn list_pro_max() {
         let tok = lex_insecure(
             b"
@@ -105,14 +105,14 @@ mod tuple_syntax {
     use super::*;
     use crate::engine::ql::{ast::parse_ast_node_full, dml::ins::DataTuple};
 
-    #[test]
+    #[sky_macros::test]
     fn tuple_mini() {
         let tok = lex_insecure(b"()").unwrap();
         let r = parse_ast_node_full::<DataTuple>(&tok[1..]).unwrap();
         assert_eq!(r, vec![]);
     }
 
-    #[test]
+    #[sky_macros::test]
     fn tuple() {
         let tok = lex_insecure(
             br#"
@@ -127,7 +127,7 @@ mod tuple_syntax {
         );
     }
 
-    #[test]
+    #[sky_macros::test]
     fn tuple_pro() {
         let tok = lex_insecure(
             br#"
@@ -152,7 +152,7 @@ mod tuple_syntax {
         );
     }
 
-    #[test]
+    #[sky_macros::test]
     fn tuple_pro_max() {
         let tok = lex_insecure(
             br#"
@@ -195,14 +195,14 @@ mod map_syntax {
     use super::*;
     use crate::engine::ql::{ast::parse_ast_node_full, dml::ins::DataMap};
 
-    #[test]
+    #[sky_macros::test]
     fn map_mini() {
         let tok = lex_insecure(b"{}").unwrap();
         let r = parse_ast_node_full::<DataMap>(&tok[1..]).unwrap();
         assert_eq!(r, null_dict! {})
     }
 
-    #[test]
+    #[sky_macros::test]
     fn map() {
         let tok = lex_insecure(
             br#"
@@ -227,7 +227,7 @@ mod map_syntax {
         )
     }
 
-    #[test]
+    #[sky_macros::test]
     fn map_pro() {
         let tok = lex_insecure(
             br#"
@@ -254,7 +254,7 @@ mod map_syntax {
         )
     }
 
-    #[test]
+    #[sky_macros::test]
     fn map_pro_max() {
         let tok = lex_insecure(br#"
                 {
@@ -301,7 +301,7 @@ mod stmt_insert {
         },
     };
 
-    #[test]
+    #[sky_macros::test]
     fn insert_tuple_mini() {
         let x = lex_insecure(
             br#"
@@ -316,7 +316,7 @@ mod stmt_insert {
         );
         assert_eq!(e, r);
     }
-    #[test]
+    #[sky_macros::test]
     fn insert_tuple() {
         let x = lex_insecure(
             br#"
@@ -340,7 +340,7 @@ mod stmt_insert {
         );
         assert_eq!(e, r);
     }
-    #[test]
+    #[sky_macros::test]
     fn insert_tuple_pro() {
         let x = lex_insecure(
             br#"
@@ -377,7 +377,7 @@ mod stmt_insert {
         );
         assert_eq!(e, r);
     }
-    #[test]
+    #[sky_macros::test]
     fn insert_map_mini() {
         let tok = lex_insecure(
             br#"
@@ -395,7 +395,7 @@ mod stmt_insert {
         );
         assert_eq!(e, r);
     }
-    #[test]
+    #[sky_macros::test]
     fn insert_map() {
         let tok = lex_insecure(
             br#"
@@ -425,7 +425,7 @@ mod stmt_insert {
         );
         assert_eq!(e, r);
     }
-    #[test]
+    #[sky_macros::test]
     fn insert_map_pro() {
         let tok = lex_insecure(
             br#"
@@ -461,7 +461,7 @@ mod stmt_insert {
         );
         assert_eq!(r, e);
     }
-    #[test]
+    #[sky_macros::test]
     fn insert_tuple_fnsub() {
         let tok =
             lex_insecure(br#"insert into jotsy.app(@uuidstr(), "sayan", @timesec())"#).unwrap();
@@ -474,7 +474,7 @@ mod stmt_insert {
         );
         assert_eq!(ret, expected);
     }
-    #[test]
+    #[sky_macros::test]
     fn insert_map_fnsub() {
         let tok = lex_insecure(
             br#"insert into jotsy.app { uuid: @uuidstr(), username: "sayan", signup_time: @timesec() }"#
@@ -505,7 +505,7 @@ mod stmt_select {
             },
         },
     };
-    #[test]
+    #[sky_macros::test]
     fn select_mini() {
         let tok = lex_insecure(
             br#"
@@ -526,7 +526,7 @@ mod stmt_select {
         );
         assert_eq!(r, e);
     }
-    #[test]
+    #[sky_macros::test]
     fn select() {
         let tok = lex_insecure(
             br#"
@@ -547,7 +547,7 @@ mod stmt_select {
         );
         assert_eq!(r, e);
     }
-    #[test]
+    #[sky_macros::test]
     fn select_pro() {
         let tok = lex_insecure(
             br#"
@@ -568,7 +568,7 @@ mod stmt_select {
         );
         assert_eq!(r, e);
     }
-    #[test]
+    #[sky_macros::test]
     fn select_pro_max() {
         let tok = lex_insecure(
             br#"
@@ -599,7 +599,7 @@ mod expression_tests {
             ql::{ast::parse_ast_node_full, dml::upd::AssignmentExpression, lex::Ident},
         },
     };
-    #[test]
+    #[sky_macros::test]
     fn expr_assign() {
         let src = lex_insecure(b"username = 'sayan'").unwrap();
         let r = parse_ast_node_full::<AssignmentExpression>(&src).unwrap();
@@ -612,7 +612,7 @@ mod expression_tests {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn expr_add_assign() {
         let src = lex_insecure(b"followers += 100").unwrap();
         let r = parse_ast_node_full::<AssignmentExpression>(&src).unwrap();
@@ -625,7 +625,7 @@ mod expression_tests {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn expr_sub_assign() {
         let src = lex_insecure(b"following -= 150").unwrap();
         let r = parse_ast_node_full::<AssignmentExpression>(&src).unwrap();
@@ -638,7 +638,7 @@ mod expression_tests {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn expr_mul_assign() {
         let src = lex_insecure(b"product_qty *= 2").unwrap();
         let r = parse_ast_node_full::<AssignmentExpression>(&src).unwrap();
@@ -651,7 +651,7 @@ mod expression_tests {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn expr_div_assign() {
         let src = lex_insecure(b"image_crop_factor /= 2").unwrap();
         let r = parse_ast_node_full::<AssignmentExpression>(&src).unwrap();
@@ -681,7 +681,7 @@ mod update_statement {
             },
         },
     };
-    #[test]
+    #[sky_macros::test]
     fn update_mini() {
         let tok = lex_insecure(
             br#"
@@ -707,7 +707,7 @@ mod update_statement {
         );
         assert_eq!(r, e);
     }
-    #[test]
+    #[sky_macros::test]
     fn update() {
         let tok = lex_insecure(
             br#"
@@ -760,7 +760,7 @@ mod delete_stmt {
         },
     };
 
-    #[test]
+    #[sky_macros::test]
     fn delete_mini() {
         let tok = lex_insecure(
             br#"
@@ -783,7 +783,7 @@ mod delete_stmt {
             e
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn delete() {
         let tok = lex_insecure(
             br#"
@@ -816,7 +816,7 @@ mod relational_expr {
         },
     };
 
-    #[test]
+    #[sky_macros::test]
     fn expr_eq() {
         let expr = lex_insecure(b"primary_key = 10").unwrap();
         let r = parse_ast_node_full::<RelationalExpr>(&expr).unwrap();
@@ -829,7 +829,7 @@ mod relational_expr {
             }
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn expr_ne() {
         let expr = lex_insecure(b"primary_key != 10").unwrap();
         let r = parse_ast_node_full::<RelationalExpr>(&expr).unwrap();
@@ -842,7 +842,7 @@ mod relational_expr {
             }
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn expr_gt() {
         let expr = lex_insecure(b"primary_key > 10").unwrap();
         let r = parse_ast_node_full::<RelationalExpr>(&expr).unwrap();
@@ -855,7 +855,7 @@ mod relational_expr {
             }
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn expr_ge() {
         let expr = lex_insecure(b"primary_key >= 10").unwrap();
         let r = parse_ast_node_full::<RelationalExpr>(&expr).unwrap();
@@ -868,7 +868,7 @@ mod relational_expr {
             }
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn expr_lt() {
         let expr = lex_insecure(b"primary_key < 10").unwrap();
         let r = parse_ast_node_full::<RelationalExpr>(&expr).unwrap();
@@ -881,7 +881,7 @@ mod relational_expr {
             }
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn expr_le() {
         let expr = lex_insecure(b"primary_key <= 10").unwrap();
         let r = parse_ast_node_full::<RelationalExpr>(&expr).unwrap();
@@ -907,7 +907,7 @@ mod where_clause {
             },
         },
     };
-    #[test]
+    #[sky_macros::test]
     fn where_single() {
         let tok = lex_insecure(
             br#"
@@ -924,7 +924,7 @@ mod where_clause {
         });
         assert_eq!(expected, parse_ast_node_full::<WhereClause>(&tok).unwrap());
     }
-    #[test]
+    #[sky_macros::test]
     fn where_double() {
         let tok = lex_insecure(
             br#"
@@ -946,7 +946,7 @@ mod where_clause {
         });
         assert_eq!(expected, parse_ast_node_full::<WhereClause>(&tok).unwrap());
     }
-    #[test]
+    #[sky_macros::test]
     fn where_duplicate_condition() {
         let tok = lex_insecure(
             br#"
@@ -967,7 +967,7 @@ mod select_all {
         },
     };
 
-    #[test]
+    #[sky_macros::test]
     fn select_all_wildcard() {
         let tok = lex_insecure(b"select all * from mymodel limit 100").unwrap();
         assert_eq!(
@@ -976,7 +976,7 @@ mod select_all {
         );
     }
 
-    #[test]
+    #[sky_macros::test]
     fn select_all_multiple_fields() {
         let tok = lex_insecure(b"select all username, password from mymodel limit 100").unwrap();
         assert_eq!(
@@ -990,7 +990,7 @@ mod select_all {
         );
     }
 
-    #[test]
+    #[sky_macros::test]
     fn select_all_missing_limit() {
         let tok = lex_insecure(b"select all * from mymodel").unwrap();
         assert_eq!(
@@ -1017,7 +1017,7 @@ mod truncate {
         },
     };
 
-    #[test]
+    #[sky_macros::test]
     fn truncate_model() {
         let tok = lex_insecure(b"truncate model myspace.mymodel").unwrap();
         assert_eq!(
@@ -1046,7 +1046,7 @@ mod insert_dyn_list {
     const LIST_CLOSE: char = PROTO_PARAM_SYM_LIST_CLOSE as char;
     const LIST_OPEN: char = PROTO_PARAM_SYM_LIST_OPEN as char;
 
-    #[test]
+    #[sky_macros::test]
     fn insert_dyn_list() {
         let query = "insert into twitter.users (?, ?)";
         let params = format!(

--- a/server/src/engine/ql/tests/lexer_tests.rs
+++ b/server/src/engine/ql/tests/lexer_tests.rs
@@ -41,7 +41,7 @@ macro_rules! v(
     }};
 );
 
-#[test]
+#[sky_macros::test]
 fn lex_ident() {
     let src = v!("hello");
     assert_eq!(
@@ -51,7 +51,7 @@ fn lex_ident() {
 }
 
 // literals
-#[test]
+#[sky_macros::test]
 fn lex_unsigned_int() {
     let number = v!("123456");
     assert_eq!(
@@ -59,7 +59,7 @@ fn lex_unsigned_int() {
         vec![Token::Lit(Lit::new_uint(123456))]
     );
 }
-#[test]
+#[sky_macros::test]
 fn lex_signed_int() {
     let number = v!("-123456");
     assert_eq!(
@@ -67,7 +67,7 @@ fn lex_signed_int() {
         vec![Token::Lit(Lit::new_sint(-123456))]
     );
 }
-#[test]
+#[sky_macros::test]
 fn lex_bool() {
     let (t, f) = v!("true", "false");
     assert_eq!(
@@ -79,7 +79,7 @@ fn lex_bool() {
         vec![Token::Lit(Lit::new_bool(false))]
     );
 }
-#[test]
+#[sky_macros::test]
 fn lex_string() {
     let s = br#" "hello, world" "#;
     assert_eq!(
@@ -92,7 +92,7 @@ fn lex_string() {
         vec![Token::Lit(Lit::new_string("hello, world".into()))]
     );
 }
-#[test]
+#[sky_macros::test]
 fn lex_string_test_escape_quote() {
     let s = br#" "\"hello world\"" "#; // == "hello world"
     assert_eq!(
@@ -105,7 +105,7 @@ fn lex_string_test_escape_quote() {
         vec![Token::Lit(Lit::new_string("'hello world'".into()))]
     );
 }
-#[test]
+#[sky_macros::test]
 fn lex_string_use_different_quote_style() {
     let s = br#" "he's on it" "#;
     assert_eq!(
@@ -120,7 +120,7 @@ fn lex_string_use_different_quote_style() {
         ))]
     )
 }
-#[test]
+#[sky_macros::test]
 fn lex_string_escape_bs() {
     let s = v!(r#" "windows has c:\\" "#);
     assert_eq!(
@@ -140,31 +140,31 @@ fn lex_string_escape_bs() {
         "lol"
     )
 }
-#[test]
+#[sky_macros::test]
 fn lex_string_bad_escape() {
     let wth = br#" '\a should be an alert on windows apparently' "#;
     assert_eq!(lex_insecure(wth).unwrap_err(), QueryError::LexInvalidInput);
 }
-#[test]
+#[sky_macros::test]
 fn lex_string_unclosed() {
     let wth = br#" 'omg where did the end go "#;
     assert_eq!(lex_insecure(wth).unwrap_err(), QueryError::LexInvalidInput);
     let wth = br#" 'see, we escaped the end\' "#;
     assert_eq!(lex_insecure(wth).unwrap_err(), QueryError::LexInvalidInput);
 }
-#[test]
+#[sky_macros::test]
 fn lex_unsafe_literal_mini() {
     let usl = lex_insecure("\r0\n".as_bytes()).unwrap();
     assert_eq!(usl.len(), 1);
     assert_eq!(Token::Lit(Lit::new_bin(b"")), usl[0]);
 }
-#[test]
+#[sky_macros::test]
 fn lex_unsafe_literal() {
     let usl = lex_insecure("\r9\nabcdefghi".as_bytes()).unwrap();
     assert_eq!(usl.len(), 1);
     assert_eq!(Token::Lit(Lit::new_bin(b"abcdefghi")), usl[0]);
 }
-#[test]
+#[sky_macros::test]
 fn lex_unsafe_literal_pro() {
     let usl = lex_insecure("\r18\nabcdefghi123456789".as_bytes()).unwrap();
     assert_eq!(usl.len(), 1);
@@ -182,7 +182,7 @@ fn make_safe_query(a: &[u8], b: &[u8]) -> (Vec<u8>, usize) {
     (s, a.len())
 }
 
-#[test]
+#[sky_macros::test]
 fn safe_query_param_empty() {
     for i in 0..100 {
         let (query, query_window) = make_safe_query(&b"?".repeat(i), b"");
@@ -194,7 +194,7 @@ fn safe_query_param_empty() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn safe_query_less_param() {
     for i in 1..=10 {
         /*
@@ -219,7 +219,7 @@ fn safe_query_less_param() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn safe_query_all_literals() {
     let (query, query_window) = make_safe_query(
         b"? ? ? ? ? ? ?",
@@ -249,14 +249,14 @@ const SFQ_FLOAT: &[u8] = b"\x043.141592654\n";
 const SFQ_BINARY: &[u8] = "\x0546\ncringe😃😄😁😆😅😂🤣😊😸😺".as_bytes();
 const SFQ_STRING: &[u8] = "\x0646\ncringe😃😄😁😆😅😂🤣😊😸😺".as_bytes();
 
-#[test]
+#[sky_macros::test]
 fn safe_query_null() {
     let (query, query_window) = make_safe_query(b"?", SFQ_NULL);
     let r = lex_secure(&query, query_window).unwrap();
     assert_eq!(r, vec![Token![null]])
 }
 
-#[test]
+#[sky_macros::test]
 fn safe_query_bool() {
     let (query, query_window) = make_safe_query(b"?", SFQ_BOOL_FALSE);
     let b_false = lex_secure(&query, query_window).unwrap();
@@ -271,28 +271,28 @@ fn safe_query_bool() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn safe_query_uint() {
     let (query, query_window) = make_safe_query(b"?", SFQ_UINT);
     let int = lex_secure(&query, query_window).unwrap();
     assert_eq!(int, vec![Token::Lit(Lit::new_uint(u64::MAX))]);
 }
 
-#[test]
+#[sky_macros::test]
 fn safe_query_sint() {
     let (query, query_window) = make_safe_query(b"?", SFQ_SINT);
     let int = lex_secure(&query, query_window).unwrap();
     assert_eq!(int, vec![Token::Lit(Lit::new_sint(i64::MIN))]);
 }
 
-#[test]
+#[sky_macros::test]
 fn safe_query_float() {
     let (query, query_window) = make_safe_query(b"?", SFQ_FLOAT);
     let float = lex_secure(&query, query_window).unwrap();
     assert_eq!(float, vec![Token::Lit(Lit::new_float(3.141592654))]);
 }
 
-#[test]
+#[sky_macros::test]
 fn safe_query_binary() {
     for (test_payload_string, expected) in [
         (b"\x050\n".as_slice(), b"".as_slice()),
@@ -304,7 +304,7 @@ fn safe_query_binary() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn safe_query_string() {
     for (test_payload_string, expected) in [
         (b"\x060\n".as_slice(), ""),
@@ -316,7 +316,7 @@ fn safe_query_string() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn safe_params_shuffled() {
     let expected = [
         (SFQ_NULL, Token![null]),

--- a/server/src/engine/ql/tests/misc.rs
+++ b/server/src/engine/ql/tests/misc.rs
@@ -34,7 +34,7 @@ use crate::engine::ql::{
     entity
 */
 
-#[test]
+#[sky_macros::test]
 fn entity_current() {
     let t = lex_insecure(b"hello").unwrap();
     let mut state = State::new_inplace(&t);
@@ -43,7 +43,7 @@ fn entity_current() {
     assert_eq!(r, ("apps", "hello").into());
 }
 
-#[test]
+#[sky_macros::test]
 fn entity_full() {
     let t = lex_insecure(b"hello.world").unwrap();
     let mut state = State::new_inplace(&t);
@@ -57,7 +57,7 @@ fn entity_full() {
     use
 */
 
-#[test]
+#[sky_macros::test]
 fn use_new() {
     let t = lex_insecure(b"use myspace").unwrap();
     let mut state = State::new_inplace(&t[1..]);
@@ -67,14 +67,14 @@ fn use_new() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn use_null() {
     let t = lex_insecure(b"use null").unwrap();
     let mut state = State::new_inplace(&t[1..]);
     assert_eq!(Use::test_parse_from_state(&mut state).unwrap(), Use::Null);
 }
 
-#[test]
+#[sky_macros::test]
 fn use_current() {
     let t = lex_insecure(b"use $current").unwrap();
     let mut state = State::new_inplace(&t[1..]);
@@ -84,7 +84,7 @@ fn use_current() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn inspect_global() {
     let t = lex_insecure(b"inspect global").unwrap();
     let mut state = State::new_inplace(&t[1..]);
@@ -94,7 +94,7 @@ fn inspect_global() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn inspect_space() {
     let t = lex_insecure(b"inspect space myspace").unwrap();
     let mut state = State::new_inplace(&t[1..]);
@@ -104,7 +104,7 @@ fn inspect_space() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn inspect_model() {
     let t = lex_insecure(b"inspect model myspace.mymodel").unwrap();
     let mut state = State::new_inplace(&t[1..]);

--- a/server/src/engine/ql/tests/schema_tests.rs
+++ b/server/src/engine/ql/tests/schema_tests.rs
@@ -31,13 +31,13 @@ use {
 
 mod alter_space {
     use {super::*, crate::engine::ql::ddl::alt::AlterSpace};
-    #[test]
+    #[sky_macros::test]
     fn alter_space_mini() {
         fullparse_verify_substmt("alter model mymodel with {}", |r: AlterSpace| {
             assert_eq!(r, AlterSpace::new(Ident::from("mymodel"), null_dict! {}));
         })
     }
-    #[test]
+    #[sky_macros::test]
     fn alter_space() {
         fullparse_verify_substmt(
             r#"
@@ -66,19 +66,19 @@ mod tymeta {
         ast::{parse_ast_node_full, State},
         ddl::syn::{DictTypeMeta, DictTypeMetaSplit},
     };
-    #[test]
+    #[sky_macros::test]
     fn tymeta_mini() {
         let tok = lex_insecure(b"{}").unwrap();
         let tymeta = parse_ast_node_full::<DictTypeMeta>(&tok).unwrap();
         assert_eq!(tymeta, null_dict!());
     }
-    #[test]
+    #[sky_macros::test]
     #[should_panic]
     fn tymeta_mini_fail() {
         let tok = lex_insecure(b"{,}").unwrap();
         parse_ast_node_full::<DictTypeMeta>(&tok).unwrap();
     }
-    #[test]
+    #[sky_macros::test]
     fn tymeta() {
         let tok = lex_insecure(br#"{hello: "world", loading: true, size: 100 }"#).unwrap();
         let tymeta = parse_ast_node_full::<DictTypeMeta>(&tok).unwrap();
@@ -91,7 +91,7 @@ mod tymeta {
             }
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn tymeta_pro() {
         // list { maxlen: 100, type: string, unique: true }
         //        ^^^^^^^^^^^^^^^^^^ cursor should be at string
@@ -114,7 +114,7 @@ mod tymeta {
             }
         )
     }
-    #[test]
+    #[sky_macros::test]
     fn tymeta_pro_max() {
         // list { maxlen: 100, this: { is: "cool" }, type: string, unique: true }
         //        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cursor should be at string
@@ -146,7 +146,7 @@ mod tymeta {
 mod layer {
     use super::*;
     use crate::engine::ql::{ast::parse_ast_node_multiple_full, ddl::syn::LayerSpec};
-    #[test]
+    #[sky_macros::test]
     fn layer_mini() {
         let tok = lex_insecure(b"string").unwrap();
         let layers = parse_ast_node_multiple_full::<LayerSpec>(&tok).unwrap();
@@ -155,7 +155,7 @@ mod layer {
             vec![LayerSpec::new(Ident::from("string"), null_dict! {})]
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn layer() {
         let tok = lex_insecure(b"string { maxlen: 100 }").unwrap();
         let layers = parse_ast_node_multiple_full::<LayerSpec>(&tok).unwrap();
@@ -169,7 +169,7 @@ mod layer {
             )]
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn layer_plus() {
         let tok = lex_insecure(b"list { type: string }").unwrap();
         let layers = parse_ast_node_multiple_full::<LayerSpec>(&tok).unwrap();
@@ -181,7 +181,7 @@ mod layer {
             ]
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn layer_pro() {
         let tok = lex_insecure(b"list { unique: true, type: string, maxlen: 10 }").unwrap();
         let layers = parse_ast_node_multiple_full::<LayerSpec>(&tok).unwrap();
@@ -199,7 +199,7 @@ mod layer {
             ]
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn layer_pro_max() {
         let tok = lex_insecure(
             b"list { unique: true, type: string { ascii_only: true, maxlen: 255 }, maxlen: 10 }",
@@ -227,7 +227,7 @@ mod layer {
         );
     }
 
-    #[test]
+    #[sky_macros::test]
     #[cfg(not(miri))]
     fn fuzz_layer() {
         let tok = b"
@@ -270,7 +270,7 @@ mod fields {
             ddl::syn::{FieldSpec, LayerSpec},
         },
     };
-    #[test]
+    #[sky_macros::test]
     fn field_mini() {
         let tok = lex_insecure(b"username: string").unwrap();
         let f = parse_ast_node_full::<FieldSpec>(&tok).unwrap();
@@ -284,7 +284,7 @@ mod fields {
             )
         )
     }
-    #[test]
+    #[sky_macros::test]
     fn field() {
         let tok = lex_insecure(b"primary username: string").unwrap();
         let f = parse_ast_node_full::<FieldSpec>(&tok).unwrap();
@@ -298,7 +298,7 @@ mod fields {
             )
         )
     }
-    #[test]
+    #[sky_macros::test]
     fn field_pro() {
         let tok = lex_insecure(
             b"
@@ -327,7 +327,7 @@ mod fields {
             )
         )
     }
-    #[test]
+    #[sky_macros::test]
     fn field_pro_max() {
         let tok = lex_insecure(
             b"
@@ -374,7 +374,7 @@ mod schemas {
         crt::CreateModel,
         syn::{FieldSpec, LayerSpec},
     };
-    #[test]
+    #[sky_macros::test]
     fn schema_mini() {
         let mut ret = CreateModel::new(
             ("apps", "mymodel").into(),
@@ -413,7 +413,7 @@ mod schemas {
             |r: CreateModel| assert_eq!(r, ret),
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn schema() {
         let mut ret = CreateModel::new(
             ("apps", "mymodel").into(),
@@ -461,7 +461,7 @@ mod schemas {
         );
     }
 
-    #[test]
+    #[sky_macros::test]
     fn schema_pro() {
         let mut ret = CreateModel::new(
             ("apps", "mymodel").into(),
@@ -519,7 +519,7 @@ mod schemas {
             |r: CreateModel| assert_eq!(ret, r),
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn schema_pro_max() {
         let mut ret = CreateModel::new(
             ("apps", "mymodel").into(),
@@ -593,7 +593,7 @@ mod dict_field_syntax {
         ast::parse_ast_node_full,
         ddl::syn::{ExpandedField, LayerSpec},
     };
-    #[test]
+    #[sky_macros::test]
     fn field_syn_mini() {
         let tok = lex_insecure(b"username { type: string }").unwrap();
         let ef = parse_ast_node_full::<ExpandedField>(&tok).unwrap();
@@ -606,7 +606,7 @@ mod dict_field_syntax {
             )
         )
     }
-    #[test]
+    #[sky_macros::test]
     fn field_syn() {
         let tok = lex_insecure(
             b"
@@ -629,7 +629,7 @@ mod dict_field_syntax {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn field_syn_pro() {
         let tok = lex_insecure(
             b"
@@ -663,7 +663,7 @@ mod dict_field_syntax {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn field_syn_pro_max() {
         let tok = lex_insecure(
             b"
@@ -713,7 +713,7 @@ mod alter_model_remove {
         ast::parse_ast_node_full_with_space,
         ddl::alt::{AlterKind, AlterModel},
     };
-    #[test]
+    #[sky_macros::test]
     fn alter_mini() {
         let tok = lex_insecure(b"alter model mymodel remove myfield").unwrap();
         let remove = parse_ast_node_full_with_space::<AlterModel>(&tok[2..], "apps").unwrap();
@@ -725,7 +725,7 @@ mod alter_model_remove {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn alter_mini_2() {
         let tok = lex_insecure(b"alter model mymodel remove (myfield)").unwrap();
         let remove = parse_ast_node_full_with_space::<AlterModel>(&tok[2..], "apps").unwrap();
@@ -737,7 +737,7 @@ mod alter_model_remove {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn alter() {
         let tok =
             lex_insecure(b"alter model mymodel remove (myfield1, myfield2, myfield3, myfield4)")
@@ -766,7 +766,7 @@ mod alter_model_add {
             syn::{ExpandedField, LayerSpec},
         },
     };
-    #[test]
+    #[sky_macros::test]
     fn add_mini() {
         let tok = lex_insecure(
             b"
@@ -789,7 +789,7 @@ mod alter_model_add {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn add() {
         let tok = lex_insecure(
             b"
@@ -815,7 +815,7 @@ mod alter_model_add {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn add_pro() {
         let tok = lex_insecure(
             b"
@@ -841,7 +841,7 @@ mod alter_model_add {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn add_pro_max() {
         let tok = lex_insecure(
             b"
@@ -915,7 +915,7 @@ mod alter_model_update {
         },
     };
 
-    #[test]
+    #[sky_macros::test]
     fn alter_mini() {
         let tok = lex_insecure(
             b"
@@ -939,7 +939,7 @@ mod alter_model_update {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn alter_mini_2() {
         let tok = lex_insecure(
             b"
@@ -963,7 +963,7 @@ mod alter_model_update {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn alter() {
         let tok = lex_insecure(
             b"
@@ -994,7 +994,7 @@ mod alter_model_update {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn alter_pro() {
         let tok = lex_insecure(
             b"
@@ -1035,7 +1035,7 @@ mod alter_model_update {
             )
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn alter_pro_max() {
         let tok = lex_insecure(
             b"
@@ -1092,7 +1092,7 @@ mod ddl_other_query_tests {
             ddl::drop::{DropModel, DropSpace},
         },
     };
-    #[test]
+    #[sky_macros::test]
     fn drop_space() {
         let src = lex_insecure(br"drop space myspace").unwrap();
         assert_eq!(
@@ -1105,7 +1105,7 @@ mod ddl_other_query_tests {
             DropSpace::new(Ident::from("myspace"), false, true)
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn drop_space_force() {
         let src = lex_insecure(br"drop space allow not empty myspace").unwrap();
         assert_eq!(
@@ -1118,7 +1118,7 @@ mod ddl_other_query_tests {
             DropSpace::new(Ident::from("myspace"), true, true)
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn drop_model() {
         let src = lex_insecure(br"drop model mymodel").unwrap();
         assert_eq!(
@@ -1131,7 +1131,7 @@ mod ddl_other_query_tests {
             DropModel::new(("apps", "mymodel").into(), false, true)
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn drop_model_force() {
         let src = lex_insecure(br"drop model allow not empty mymodel").unwrap();
         assert_eq!(

--- a/server/src/engine/ql/tests/structure_syn.rs
+++ b/server/src/engine/ql/tests/structure_syn.rs
@@ -50,7 +50,7 @@ fn fold_dict(raw: &[u8]) -> Option<DictGeneric> {
 mod dict {
     use super::*;
 
-    #[test]
+    #[sky_macros::test]
     fn dict_read_mini() {
         let (d1, d2) = fold_dict! {
             br#"{name: "sayan"}"#,
@@ -59,7 +59,7 @@ mod dict {
         let r = null_dict!("name" => Lit::new_string("sayan".into()));
         multi_assert_eq!(d1, d2 => r);
     }
-    #[test]
+    #[sky_macros::test]
     fn dict_read() {
         let (d1, d2) = fold_dict! {
             br#"
@@ -84,7 +84,7 @@ mod dict {
         );
         multi_assert_eq!(d1, d2 => r);
     }
-    #[test]
+    #[sky_macros::test]
     fn dict_read_pro() {
         let (d1, d2, d3) = fold_dict! {
             br#"
@@ -129,7 +129,7 @@ mod dict {
         );
     }
 
-    #[test]
+    #[sky_macros::test]
     fn dict_read_pro_max() {
         let (d1, d2, d3) = fold_dict! {
             br#"
@@ -187,7 +187,7 @@ mod dict {
         );
     }
 
-    #[test]
+    #[sky_macros::test]
     #[cfg(not(miri))]
     fn fuzz_dict() {
         let tok = b"
@@ -235,7 +235,7 @@ mod null_dict_tests {
     mod dict {
         use super::*;
 
-        #[test]
+        #[sky_macros::test]
         fn null_mini() {
             let d = fold_dict!(br"{ x: null }");
             assert_eq!(
@@ -245,7 +245,7 @@ mod null_dict_tests {
                 }
             );
         }
-        #[test]
+        #[sky_macros::test]
         fn null() {
             let d = fold_dict! {
                 br#"
@@ -263,7 +263,7 @@ mod null_dict_tests {
                 }
             )
         }
-        #[test]
+        #[sky_macros::test]
         fn null_pro() {
             let d = fold_dict! {
                 br#"
@@ -287,7 +287,7 @@ mod null_dict_tests {
                 }
             )
         }
-        #[test]
+        #[sky_macros::test]
         fn null_pro_max() {
             let d = fold_dict! {
                 br#"

--- a/server/src/engine/storage/common/sdss/impls/sdss_r1/rw.rs
+++ b/server/src/engine/storage/common/sdss/impls/sdss_r1/rw.rs
@@ -600,7 +600,7 @@ impl<
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn check_vfs_buffering() {
     use crate::engine::storage::{
         common::interface::fs::FileSystem,

--- a/server/src/engine/storage/common/sdss/impls/sdss_r1/upgrades.rs
+++ b/server/src/engine/storage/common/sdss/impls/sdss_r1/upgrades.rs
@@ -125,7 +125,7 @@ mod test_upgrade {
             }
         }
     }
-    #[test]
+    #[sky_macros::test]
     fn upgrade_test() {
         const FILE_PATH: &str = "upgrade_test_file.db";
         const FILE_DATA: &[u8] = b"hello freaking world";

--- a/server/src/engine/storage/common_encoding/r1/impls/gns/tests/full_chain.rs
+++ b/server/src/engine/storage/common_encoding/r1/impls/gns/tests/full_chain.rs
@@ -66,7 +66,7 @@ fn init_space(global: &impl GlobalInstanceLike, space_name: &str, env: &str) -> 
         .get_uuid()
 }
 
-#[test]
+#[sky_macros::test]
 fn create_space() {
     with_variable("create_space_test.global.db-tlog", |log_name| {
         let uuid;
@@ -92,7 +92,7 @@ fn create_space() {
     })
 }
 
-#[test]
+#[sky_macros::test]
 fn alter_space() {
     with_variable("alter_space_test.global.db-tlog", |log_name| {
         let uuid;
@@ -122,7 +122,7 @@ fn alter_space() {
     })
 }
 
-#[test]
+#[sky_macros::test]
 fn drop_space() {
     with_variable("drop_space_test.global.db-tlog", |log_name| {
         {
@@ -172,7 +172,7 @@ fn init_default_model(global: &impl GlobalInstanceLike) -> Uuid {
     )
 }
 
-#[test]
+#[sky_macros::test]
 fn create_model() {
     with_variable("create_model_test.global.db-tlog", |log_name| {
         let _uuid_space;
@@ -207,7 +207,7 @@ fn create_model() {
     })
 }
 
-#[test]
+#[sky_macros::test]
 fn alter_model_add() {
     with_variable("alter_model_add_test.global.db-tlog", |log_name| {
         {
@@ -238,7 +238,7 @@ fn alter_model_add() {
     })
 }
 
-#[test]
+#[sky_macros::test]
 fn alter_model_remove() {
     with_variable("alter_model_remove_test.global.db-tlog", |log_name| {
         {
@@ -272,7 +272,7 @@ fn alter_model_remove() {
     })
 }
 
-#[test]
+#[sky_macros::test]
 fn alter_model_update() {
     with_variable("alter_model_update_test.global.db-tlog", |log_name| {
         {
@@ -307,7 +307,7 @@ fn alter_model_update() {
     })
 }
 
-#[test]
+#[sky_macros::test]
 fn drop_model() {
     with_variable("drop_model_test.global.db-tlog", |log_name| {
         {

--- a/server/src/engine/storage/common_encoding/r1/impls/gns/tests/io.rs
+++ b/server/src/engine/storage/common_encoding/r1/impls/gns/tests/io.rs
@@ -45,7 +45,7 @@ mod space_tests {
         },
         crate::engine::txn::gns::space::{AlterSpaceTxn, CreateSpaceTxn, DropSpaceTxn},
     };
-    #[test]
+    #[sky_macros::test]
     fn create() {
         let orig_space = Space::new_auto_all();
         let space_r = orig_space.props();
@@ -60,7 +60,7 @@ mod space_tests {
             decoded
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn alter() {
         let space = Space::new_auto_all();
         let space_r = space.props();
@@ -75,7 +75,7 @@ mod space_tests {
             decoded
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn drop() {
         let space = Space::new_auto_all();
         let txn = DropSpaceTxn::new(super::SpaceIDRef::new("myspace", &space));
@@ -119,7 +119,7 @@ mod model_tests {
         );
         (space, model)
     }
-    #[test]
+    #[sky_macros::test]
     fn create() {
         let (space, model) = default_space_model();
         let txn = CreateModelTxn::new(super::SpaceIDRef::new("myspace", &space), "mymodel", &model);
@@ -134,7 +134,7 @@ mod model_tests {
             decoded
         )
     }
-    #[test]
+    #[sky_macros::test]
     fn alter_add() {
         let (space, model) = default_space_model();
         let new_fields = into_dict! {
@@ -166,7 +166,7 @@ mod model_tests {
             decoded
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn alter_remove() {
         let (space, model) = default_space_model();
         let removed_fields = ["profile_pic".into()];
@@ -194,7 +194,7 @@ mod model_tests {
             decoded
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn alter_update() {
         let (space, model) = default_space_model();
         let updated_fields_copy = into_dict! {
@@ -229,7 +229,7 @@ mod model_tests {
             decoded
         );
     }
-    #[test]
+    #[sky_macros::test]
     fn drop() {
         let (space, model) = default_space_model();
         let txn = DropModelTxn::new(super::ModelIDRef::new(

--- a/server/src/engine/storage/common_encoding/r1/mod.rs
+++ b/server/src/engine/storage/common_encoding/r1/mod.rs
@@ -46,7 +46,6 @@ type VecU8 = Vec<u8>;
 
 pub trait DataSource {
     type Error;
-    const RELIABLE_SOURCE: bool = true;
     fn has_remaining(&self, cnt: usize) -> bool;
     unsafe fn read_next_byte(&mut self) -> Result<u8, Self::Error>;
     unsafe fn read_next_block<const N: usize>(&mut self) -> Result<[u8; N], Self::Error>;

--- a/server/src/engine/storage/common_encoding/r1/tests.rs
+++ b/server/src/engine/storage/common_encoding/r1/tests.rs
@@ -46,7 +46,7 @@ use {
     },
 };
 
-#[test]
+#[sky_macros::test]
 fn dict() {
     let dict: DictGeneric = into_dict! {
         "hello" => Datacell::new_str("world".into()),
@@ -61,7 +61,7 @@ fn dict() {
     assert_eq!(dict, decoded);
 }
 
-#[test]
+#[sky_macros::test]
 fn layer() {
     let layer = Layer::list();
     let encoded = super::enc::full::<obj::LayerRef>(obj::LayerRef(&layer));
@@ -69,7 +69,7 @@ fn layer() {
     assert_eq!(layer, dec);
 }
 
-#[test]
+#[sky_macros::test]
 fn field() {
     let field = Field::new([Layer::list(), Layer::uint64()].into(), true);
     let encoded = super::enc::full::<obj::FieldRef>((&field).into());
@@ -77,7 +77,7 @@ fn field() {
     assert_eq!(field, dec);
 }
 
-#[test]
+#[sky_macros::test]
 fn fieldmap() {
     let mut fields = IndexSTSeqCns::<Box<str>, Field>::idx_init();
     fields.st_insert("password".into(), Field::new([Layer::bin()].into(), false));
@@ -98,7 +98,7 @@ fn fieldmap() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn model() {
     let uuid = Uuid::new();
     let model = ModelData::new_restore(
@@ -115,7 +115,7 @@ fn model() {
     assert_eq!(model, dec);
 }
 
-#[test]
+#[sky_macros::test]
 fn space() {
     let uuid = Uuid::new();
     let space = Space::new_restore_empty(uuid, Default::default());
@@ -125,7 +125,7 @@ fn space() {
     assert_eq!(space, dec);
 }
 
-#[test]
+#[sky_macros::test]
 fn dc_encode_decode() {
     fn enc_dec(dc: &Datacell) {
         let mut encoded = vec![];

--- a/server/src/engine/storage/v1/raw/batch_jrnl/restore.rs
+++ b/server/src/engine/storage/v1/raw/batch_jrnl/restore.rs
@@ -521,7 +521,6 @@ impl From<()> for ErrorHack {
 }
 
 impl DataSource for TrackedReader {
-    const RELIABLE_SOURCE: bool = false;
     type Error = ErrorHack;
     fn has_remaining(&self, cnt: usize) -> bool {
         self.remaining() >= cnt as u64

--- a/server/src/engine/storage/v1/raw/journal/raw.rs
+++ b/server/src/engine/storage/v1/raw/journal/raw.rs
@@ -79,6 +79,7 @@ pub trait JournalAdapter {
     type GlobalState;
     /// The transactional impl that makes use of this journal, should define it's error type
     type Error;
+    #[allow(dead_code)]
     /// Encode a journal event into a blob
     fn encode(event: Self::JournalEvent) -> Box<[u8]>;
     /// Decode a journal event and apply it to the global state

--- a/server/src/engine/storage/v1/raw/journal/raw.rs
+++ b/server/src/engine/storage/v1/raw/journal/raw.rs
@@ -69,8 +69,6 @@ pub fn load_journal<TA: JournalAdapter, F: sdss::sdss_r1::FileSpecV1<DecodeArgs 
 
 /// The journal adapter
 pub trait JournalAdapter {
-    /// deny any SDSS file level operations that require non-append mode writes (for example, updating the SDSS header's modify count)
-    const DENY_NONAPPEND: bool = true;
     /// enable/disable automated recovery algorithms
     const RECOVERY_PLUGIN: bool;
     /// The journal event

--- a/server/src/engine/storage/v1/raw/sysdb.rs
+++ b/server/src/engine/storage/v1/raw/sysdb.rs
@@ -48,8 +48,8 @@ fn rkey<T>(
 
 pub struct RestoredSystemDatabase {
     pub users: HashMap<Box<str>, Box<[u8]>>,
-    pub startup_counter: u64,
-    pub settings_version: u64,
+    pub _startup_counter: u64,
+    pub _settings_version: u64,
 }
 
 impl RestoredSystemDatabase {
@@ -65,8 +65,8 @@ impl RestoredSystemDatabase {
     ) -> Self {
         Self {
             users,
-            startup_counter,
-            settings_version,
+            _startup_counter: startup_counter,
+            _settings_version: settings_version,
         }
     }
     pub fn restore(name: &str) -> RuntimeResult<Self> {

--- a/server/src/engine/storage/v2/impls/mdl_journal.rs
+++ b/server/src/engine/storage/v2/impls/mdl_journal.rs
@@ -906,7 +906,6 @@ mod restore_impls {
         }
     }
     impl<'a> DataSource for TrackedReaderContext<'a, FSpecModelDataAofV1> {
-        const RELIABLE_SOURCE: bool = false;
         type Error = ErrorHack;
         fn has_remaining(&self, cnt: usize) -> bool {
             self.remaining() >= cnt as u64

--- a/server/src/engine/storage/v2/impls/tests/gns.rs
+++ b/server/src/engine/storage/v2/impls/tests/gns.rs
@@ -42,7 +42,7 @@ use crate::engine::{
     txn::gns::sysctl::AlterUserTxn,
 };
 
-#[test]
+#[sky_macros::test]
 fn compaction_test() {
     FileSystem::set_context(FSContext::Local);
     let mut fs = FileSystem::instance();

--- a/server/src/engine/storage/v2/impls/tests/model_driver/compaction_test.rs
+++ b/server/src/engine/storage/v2/impls/tests/model_driver/compaction_test.rs
@@ -44,7 +44,7 @@ use {
     std::thread,
 };
 
-#[test]
+#[sky_macros::test]
 fn compaction_test() {
     FileSystem::set_context(FSContext::Local);
     let mut fs = FileSystem::instance();

--- a/server/src/engine/storage/v2/impls/tests/model_driver/generic.rs
+++ b/server/src/engine/storage/v2/impls/tests/model_driver/generic.rs
@@ -200,7 +200,7 @@ fn run_sample_updates<K, V>(
     test runs
 */
 
-#[test]
+#[sky_macros::test]
 fn empty_model_data() {
     FileSystem::set_context(FSContext::Local);
     let mut fs = FileSystem::instance();
@@ -216,7 +216,7 @@ fn empty_model_data() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn model_data_inserts() {
     FileSystem::set_context(FSContext::Local);
     let mut fs = FileSystem::instance();
@@ -240,7 +240,7 @@ fn model_data_inserts() {
     )
 }
 
-#[test]
+#[sky_macros::test]
 #[cfg(not(all(target_os = "windows", target_pointer_width = "32")))]
 fn model_data_updates() {
     FileSystem::set_context(FSContext::Local);

--- a/server/src/engine/storage/v2/impls/tests/model_driver/mod.rs
+++ b/server/src/engine/storage/v2/impls/tests/model_driver/mod.rs
@@ -99,7 +99,7 @@ fn run_update(global: &TestGlobal, update: &str) -> QueryResult<()> {
     dml::update(global, insert)
 }
 
-#[test]
+#[sky_macros::test]
 fn truncate() {
     FileSystem::set_context(FSContext::Local);
     const LOG_NAME: &str = "truncate_log.db";

--- a/server/src/engine/storage/v2/impls/tests/model_driver/skew.rs
+++ b/server/src/engine/storage/v2/impls/tests/model_driver/skew.rs
@@ -165,7 +165,7 @@ fn emulate_skewed<U: Sized, T: Sized, const N: usize>(
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn skewed_insert_update_upsert_delete() {
     FileSystem::set_context(FSContext::Local);
     let mut fs = FileSystem::instance();
@@ -295,7 +295,7 @@ fn skewed_insert_update_upsert_delete() {
     )
 }
 
-#[test]
+#[sky_macros::test]
 fn skewed_upsert() {
     FileSystem::set_context(FSContext::Local);
     let mut fs = FileSystem::instance();

--- a/server/src/engine/storage/v2/raw/journal/raw/mod.rs
+++ b/server/src/engine/storage/v2/raw/journal/raw/mod.rs
@@ -435,6 +435,7 @@ pub trait RawJournalAdapter: Sized {
     ) -> RuntimeResult<()>;
     /// initialize this adapter
     fn initialize(j_: &JournalInitializer) -> Self;
+    #[allow(dead_code)]
     /// get a write context
     fn enter_context<'a>(adapter: &'a mut RawJournalWriter<Self>) -> Self::Context<'a>;
     /// parse event metadata

--- a/server/src/engine/storage/v2/raw/journal/raw/tests/compaction.rs
+++ b/server/src/engine/storage/v2/raw/journal/raw/tests/compaction.rs
@@ -252,7 +252,7 @@ fn genkv(i: usize) -> (String, String) {
     )
 }
 
-#[test]
+#[sky_macros::test]
 fn server_events_only() {
     {
         // create and close; net srv = 1
@@ -304,7 +304,7 @@ fn server_events_only() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn do_not_compact_unique() {
     /*
         we create multiple unique events leading to not redundancy
@@ -320,7 +320,7 @@ fn do_not_compact_unique() {
     assert_eq!(stat.recommended_action(), Recommendation::NoActionNeeded);
 }
 
-#[test]
+#[sky_macros::test]
 fn compact_because_duplicate() {
     /*
         we create multiple overlapping events leading to redundancy.
@@ -375,7 +375,7 @@ fn compact_because_duplicate() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn compact_because_server_event_exceeded() {
     /*
         instantiate journal add add keys [0,5). close.

--- a/server/src/engine/storage/v2/raw/journal/raw/tests/journal_ops.rs
+++ b/server/src/engine/storage/v2/raw/journal/raw/tests/journal_ops.rs
@@ -35,7 +35,7 @@ use {
     crate::engine::fractal::error::ErrorContext,
 };
 
-#[test]
+#[sky_macros::test]
 fn journal_open_close() {
     const JOURNAL_NAME: &str = "journal_open_close";
     {
@@ -161,7 +161,7 @@ fn journal_open_close() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn journal_with_server_single_event() {
     const JOURNAL_NAME: &str = "journal_with_server_single_event";
     {
@@ -303,7 +303,7 @@ fn journal_with_server_single_event() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn multi_boot() {
     {
         let mut j = create_journal::<SimpleDBJournal>("multiboot").unwrap();

--- a/server/src/engine/storage/v2/raw/journal/raw/tests/mod.rs
+++ b/server/src/engine/storage/v2/raw/journal/raw/tests/mod.rs
@@ -226,7 +226,7 @@ impl RawJournalAdapter for SimpleDBJournal {
     basic tests
 */
 
-#[test]
+#[sky_macros::test]
 fn encode_decode_meta() {
     let dv1 = DriverEvent::new(u128::MAX - 1, DriverEventKind::Reopened, 0, 0, 0);
     let encoded1 = dv1.encode_self();
@@ -234,7 +234,7 @@ fn encode_decode_meta() {
     assert_eq!(dv1, decoded1);
 }
 
-#[test]
+#[sky_macros::test]
 fn first_triplet_sanity() {
     // first driver event
     {
@@ -279,7 +279,7 @@ fn first_triplet_sanity() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn jw_state() {
     let state_backup;
     {

--- a/server/src/engine/storage/v2/raw/journal/raw/tests/recovery.rs
+++ b/server/src/engine/storage/v2/raw/journal/raw/tests/recovery.rs
@@ -408,7 +408,7 @@ fn apply_event_mix(jrnl: &mut RawJournalWriter<SimpleDBJournal>) -> RuntimeResul
     Ok(op_count)
 }
 
-#[test]
+#[sky_macros::test]
 fn corruption_before_close() {
     let initializers = [
         Initializer::new_driver_type(
@@ -599,7 +599,7 @@ fn corruption_before_close() {
     )
 }
 
-#[test]
+#[sky_macros::test]
 fn corruption_after_reopen() {
     let initializers = [
         Initializer::new_driver_type(
@@ -806,7 +806,7 @@ fn corruption_after_reopen() {
     )
 }
 
-#[test]
+#[sky_macros::test]
 fn corruption_at_runtime() {
     // first get the offsets to compute the size of the event
     let offset = {
@@ -993,7 +993,7 @@ fn corruption_at_runtime() {
     which is absolutely not feasible. Instead, we just ensure that the pre and post states are valid.
 */
 
-#[test]
+#[sky_macros::test]
 fn midway_corruption_close() {
     let initializers = [
         Initializer::new_driver_type("midway_corruption_close_direct", |jrnl_id| {
@@ -1165,7 +1165,7 @@ fn midway_corruption_close() {
     debug_set_offset_tracking(false);
 }
 
-#[test]
+#[sky_macros::test]
 fn midway_corruption_reopen() {
     let initializers = [
         Initializer::new(
@@ -1302,7 +1302,7 @@ fn midway_corruption_reopen() {
     debug_set_offset_tracking(false);
 }
 
-#[test]
+#[sky_macros::test]
 fn midway_corruption_at_runtime() {
     debug_set_offset_tracking(true);
     // compute offset size
@@ -1497,7 +1497,7 @@ fn emulate_failure_for_rollback(
     FileSystem::remove_file(journal_id).unwrap();
 }
 
-#[test]
+#[sky_macros::test]
 fn rollback_write_zero_empty_log() {
     emulate_failure_for_rollback(
         "rollback_empty_log_write_zero",
@@ -1515,7 +1515,7 @@ fn rollback_write_zero_empty_log() {
     );
 }
 
-#[test]
+#[sky_macros::test]
 fn rollback_write_zero_nonempty_log() {
     emulate_failure_for_rollback(
         "rollback_write_zero_nonempty_log",
@@ -1538,7 +1538,7 @@ fn rollback_write_zero_nonempty_log() {
     )
 }
 
-#[test]
+#[sky_macros::test]
 fn rollback_random_write_failure_empty_log() {
     for _ in 0..100 {
         emulate_failure_for_rollback(
@@ -1558,7 +1558,7 @@ fn rollback_random_write_failure_empty_log() {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn rollback_random_write_failure_log() {
     for _ in 0..100 {
         emulate_failure_for_rollback(

--- a/server/src/engine/storage/v2/raw/journal/tests.rs
+++ b/server/src/engine/storage/v2/raw/journal/tests.rs
@@ -187,7 +187,7 @@ fn open_log() -> (
     (db, log)
 }
 
-#[test]
+#[sky_macros::test]
 fn test_this_data() {
     array!(
         const DATA1: [&str] = ["acai berry", "billberry", "cranberry"];
@@ -442,7 +442,7 @@ impl BatchAdapterSpec for BatchDBAdapter {
     }
 }
 
-#[test]
+#[sky_macros::test]
 fn batch_simple() {
     {
         let mut batch_drv = BatchAdapter::create("mybatch").unwrap();

--- a/server/src/engine/sync/queue.rs
+++ b/server/src/engine/sync/queue.rs
@@ -173,27 +173,27 @@ impl<T> Drop for Queue<T> {
 #[cfg(test)]
 type StringQueue = Queue<String>;
 
-#[test]
+#[sky_macros::test]
 fn empty() {
     let q = StringQueue::new();
     drop(q);
 }
 
-#[test]
+#[sky_macros::test]
 fn empty_deq() {
     let g = pin();
     let q = StringQueue::new();
     assert_eq!(q.blocking_try_dequeue(&g), None);
 }
 
-#[test]
+#[sky_macros::test]
 fn empty_enq() {
     let g = pin();
     let q = StringQueue::new();
     q.blocking_enqueue("hello".into(), &g);
 }
 
-#[test]
+#[sky_macros::test]
 fn multi_eq_dq() {
     const ITEMS_L: usize = 100;
     use std::{sync::Arc, thread};

--- a/server/src/engine/tests/cfg.rs
+++ b/server/src/engine/tests/cfg.rs
@@ -56,7 +56,7 @@ fn extract_cli_args_raw(
     }))
     .unwrap()
 }
-#[test]
+#[sky_macros::test]
 fn parse_cli_args_simple() {
     let payload = "skyd --mode dev --endpoint tcp@localhost:2003";
     let cfg = extract_cli_args(payload);
@@ -66,7 +66,7 @@ fn parse_cli_args_simple() {
     };
     assert_eq!(cfg, expected);
 }
-#[test]
+#[sky_macros::test]
 fn parse_cli_args_packed() {
     let payload = "skyd --mode=dev --endpoint=tcp@localhost:2003";
     let cfg = extract_cli_args(payload);
@@ -76,7 +76,7 @@ fn parse_cli_args_packed() {
     };
     assert_eq!(cfg, expected);
 }
-#[test]
+#[sky_macros::test]
 fn parse_cli_args_multi() {
     let payload = "skyd --mode=dev --endpoint tcp@localhost:2003";
     let cfg = extract_cli_args(payload);
@@ -86,7 +86,7 @@ fn parse_cli_args_multi() {
     };
     assert_eq!(cfg, expected);
 }
-#[test]
+#[sky_macros::test]
 fn parse_validate_cli_args() {
     with_files(
         [
@@ -131,7 +131,7 @@ fn parse_validate_cli_args() {
         },
     );
 }
-#[test]
+#[sky_macros::test]
 fn parse_validate_cli_args_help_and_version() {
     let pl1 = "skyd --help";
     let pl2 = "skyd --version";
@@ -175,7 +175,7 @@ fn vars_to_args(variables: &[String]) -> ParsedRawArgs {
         })
         .collect()
 }
-#[test]
+#[sky_macros::test]
 fn parse_env_args_simple() {
     let variables = [
         format!("SKYDB_TLS_CERT=/var/skytable/keys/cert.pem"),
@@ -191,7 +191,7 @@ fn parse_env_args_simple() {
     let args = config::parse_env_args().unwrap().unwrap();
     assert_eq!(args, expected_args);
 }
-#[test]
+#[sky_macros::test]
 fn parse_env_args_multi() {
     let variables = [
         format!("SKYDB_TLS_CERT=/var/skytable/keys/cert.pem"),
@@ -208,7 +208,7 @@ fn parse_env_args_multi() {
     let args = config::parse_env_args().unwrap().unwrap();
     assert_eq!(args, expected_args);
 }
-#[test]
+#[sky_macros::test]
 fn parse_validate_env_args() {
     with_files(
         [
@@ -270,7 +270,7 @@ endpoints:
     host: 127.0.0.1
     port: 2003
     ";
-#[test]
+#[sky_macros::test]
 fn test_config_file() {
     with_files(
         [

--- a/server/src/engine/tests/client/mod.rs
+++ b/server/src/engine/tests/client/mod.rs
@@ -181,5 +181,5 @@ fn insert_list() {
         ))
         .unwrap();
     assert_eq!(username, "sayan");
-    assert_eq!(bookmarks, data);
+    assert_eq!(&bookmarks[..], data);
 }

--- a/server/src/engine/tests/client/mod.rs
+++ b/server/src/engine/tests/client/mod.rs
@@ -27,8 +27,8 @@
 use {
     skytable::{
         pipe, query,
-        query::Pipeline,
-        response::{Response, Rows, Value},
+        query::{Pipeline, QList},
+        response::{RList, Response, Rows, Value},
         Query, Response,
     },
     std::collections::HashMap,
@@ -156,4 +156,30 @@ fn truncate_is_root_only() {
             .unwrap(),
         Response::Error(5)
     );
+}
+
+#[sky_macros::dbtest]
+fn insert_list() {
+    let data = vec!["next", "ducking", "level"];
+    let mut db = db!();
+    db.query_parse::<()>(&query!("create space dynlist"))
+        .unwrap();
+    db.query_parse::<()>(&query!(
+        "create model dynlist.app(username: string, bookmarks: list {type: string})"
+    ))
+    .unwrap();
+    db.query_parse::<()>(&query!(
+        "insert into dynlist.app(?, ?)",
+        "sayan",
+        QList::new(&data)
+    ))
+    .unwrap();
+    let (username, bookmarks) = db
+        .query_parse::<(String, RList<String>)>(&query!(
+            "select * from dynlist.app where username = ?",
+            "sayan"
+        ))
+        .unwrap();
+    assert_eq!(username, "sayan");
+    assert_eq!(bookmarks, data);
 }

--- a/server/src/engine/tests/mod.rs
+++ b/server/src/engine/tests/mod.rs
@@ -29,3 +29,5 @@ mod macros;
 mod cfg;
 mod client;
 mod client_misc;
+#[cfg(miri)]
+mod safety;

--- a/server/src/engine/tests/safety/mod.rs
+++ b/server/src/engine/tests/safety/mod.rs
@@ -1,0 +1,68 @@
+/*
+ * This file is a part of Skytable
+ *
+ * Skytable (formerly known as TerrabaseDB or Skybase) is a free and open-source
+ * NoSQL database written by Sayan Nandan ("the Author") with the
+ * vision to provide flexibility in data modelling without compromising
+ * on performance, queryability or scalability.
+ *
+ * Copyright (c) 2024, Sayan Nandan <nandansayan@outlook.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+*/
+
+/*
+    while I have manually verified the safety of every component, an excruciatingly painful task involving taking each structure,
+    placing it into an executable, checking with valgrind (due to some miri limitations), followed by checking with miri itself...
+    a task that took me a few months of day and night work and investigation ... I want to slowly turn these safety checks into a
+    "routine" thing so that it's checked with every run.
+
+    Some of these are here in this module.
+
+    -- Sayan (@ohsayan); July, 2024
+*/
+
+use {
+    crate::engine::{data::cell::Datacell, ql::lex::Token},
+    sky_macros::miri_test,
+};
+
+#[miri_test]
+fn token_vector_swap() {
+    let data = vec![
+        Datacell::new_list(vec![
+            Datacell::new_str("hello".to_owned().into_boxed_str()),
+            Datacell::new_str("world".to_owned().into_boxed_str()),
+            Datacell::new_list(vec![
+                Datacell::new_str("technically".to_owned().into_boxed_str()),
+                Datacell::new_str("this".to_owned().into_boxed_str()),
+                Datacell::new_str("is".to_owned().into_boxed_str()),
+                Datacell::new_str("an".to_owned().into_boxed_str()),
+                Datacell::new_bin(b"illegal".to_vec().into_boxed_slice()),
+                Datacell::new_bin(b"list".to_vec().into_boxed_slice()),
+            ]),
+        ]),
+        Datacell::new_uint_default(u64::MAX),
+    ];
+    let token = Token::dc_list(data.clone());
+    let taken_list = match &token {
+        Token::DCList(dcl) => unsafe {
+            // UNSAFE(@ohsayan): this is actually fine since we're the only thread
+            Token::take_list(dcl)
+        },
+        _ => panic!(),
+    };
+    assert_eq!(taken_list, data);
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -24,8 +24,6 @@
  *
 */
 
-#![forbid(unused_crate_dependencies)]
-#![deny(unused_imports, unused_must_use)]
 #![cfg_attr(feature = "nightly", feature(test))]
 
 //! # Skytable

--- a/server/src/util/os.rs
+++ b/server/src/util/os.rs
@@ -143,7 +143,7 @@ mod unix {
         }
     }
 
-    #[test]
+    #[sky_macros::test]
     fn test_ulimit() {
         let _ = ResourceLimit::get().unwrap();
     }
@@ -476,7 +476,7 @@ mod hostname_impl {
             String::from_utf8_lossy(&x).trim().to_string()
         }
 
-        #[test]
+        #[sky_macros::test]
         fn t_get_hostname() {
             assert_eq!(
                 test_get_hostname().as_str(),
@@ -513,7 +513,7 @@ fn rmove(src: &Path, dst: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-#[test]
+#[sky_macros::test]
 fn rcopy_okay() {
     let dir_paths = [
         "testdata/backups",
@@ -554,7 +554,7 @@ fn rcopy_okay() {
     fs::remove_dir_all("my-backups").unwrap();
 }
 
-#[test]
+#[sky_macros::test]
 fn t_uptime() {
     use std::{thread, time::Duration};
     let uptime_1 = get_uptime();

--- a/server/src/util/os/flock.rs
+++ b/server/src/util/os/flock.rs
@@ -61,7 +61,7 @@ impl FileLock {
             let mut overlapped = OVERLAPPED::default();
             unsafe {
                 LockFileEx(
-                    HANDLE(handle as isize),
+                    HANDLE(handle),
                     LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
                     0,
                     u32::MAX as u32,
@@ -71,7 +71,7 @@ impl FileLock {
             }?;
             return Ok(Self {
                 _file: file,
-                handle: HANDLE(handle as isize),
+                handle: HANDLE(handle),
             });
         }
         #[cfg(unix)]

--- a/sky-bench/Cargo.toml
+++ b/sky-bench/Cargo.toml
@@ -17,6 +17,6 @@ libsky = { path = "../libsky" }
 # external deps
 crossbeam-channel = "0.5.13"
 num_cpus = "1.16.0"
-env_logger = "0.11.3"
-log = "0.4.21"
-tokio = { version = "1.38.0", features = ["full"] }
+env_logger = "0.11.4"
+log = "0.4.22"
+tokio = { version = "1.39.1", features = ["full"] }

--- a/sky-macros/src/dbtest.rs
+++ b/sky-macros/src/dbtest.rs
@@ -145,7 +145,7 @@ fn parse_attrs(attrs: AttributeArgs) -> TestSetup {
                 }
                 unknown => panic!("unknown nested attribute `{unknown}`"),
             },
-            AttributeKind::Path(_) | AttributeKind::Lit(_) => {
+            AttributeKind::Path { .. } | AttributeKind::Lit { .. } => {
                 panic!("unexpected tokens")
             }
         }

--- a/sky-macros/src/dbtest.rs
+++ b/sky-macros/src/dbtest.rs
@@ -288,7 +288,7 @@ pub fn dbtest(attrs: TokenStream, item: TokenStream) -> TokenStream {
         TestStrategy::Standard => {}
     }
     let ret = quote! {
-        #[core::prelude::v1::test]
+        #[::sky_macros::test]
         #retfn {
             #ret_block
         }

--- a/sky-macros/src/util.rs
+++ b/sky-macros/src/util.rs
@@ -30,10 +30,10 @@ use {
 };
 
 pub enum AttributeKind {
-    Lit(Lit),
+    Lit { _l: Lit },
     NestedAttrs { name: Ident, attrs: Vec<Self> },
     Pair(Ident, Lit),
-    Path(Path),
+    Path { _p: Path },
 }
 
 impl AttributeKind {
@@ -47,7 +47,7 @@ impl AttributeKind {
 
 pub fn extract_attribute(attr: &NestedMeta) -> AttributeKind {
     match attr {
-        NestedMeta::Lit(l) => AttributeKind::Lit(l.clone()),
+        NestedMeta::Lit(l) => AttributeKind::Lit { _l: l.clone() },
         NestedMeta::Meta(m) => match m {
             Meta::List(l) => AttributeKind::NestedAttrs {
                 name: l.path.get_ident().unwrap().clone(),
@@ -56,7 +56,7 @@ pub fn extract_attribute(attr: &NestedMeta) -> AttributeKind {
             Meta::NameValue(MetaNameValue { path, lit, .. }) => {
                 AttributeKind::Pair(path.get_ident().unwrap().clone(), lit.clone())
             }
-            Meta::Path(p) => AttributeKind::Path(p.clone()),
+            Meta::Path(p) => AttributeKind::Path { _p: p.clone() },
         },
     }
 }


### PR DESCRIPTION
Previously we only supported lists in queries using the list syntax (`[?, ?]`) but this prevents the use of lists with undecided capacities. Also, using a string buffer and adding it simply defeats the security measures that we enforce so strictly.

To solve this, we now allow lists to be passed as a parameter in Skyhash.

---
✔️ By submitting this pull request, I agree to the CLA at: https://cla.skytable.io/skytable/skytable
