### PR TITLE
server [BQL]: Add simple list syntax for DDL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ All changes in this project will be noted in this file.
 - Server:
   - Added `TRUNCATE MODEL` query (and no, I still have no idea why this wasn't present in the first place. There are some things in the universe that no one knows the answer to. This is one of those things.)
     > Also note: `TRUNCATE MODEL` is root only right now.
-  - Simple lists can now be defined using simple list syntax. For example, instead of `create model mymodel(uid: username, notes: list { type: string })`
-    you will now be able to simply use `create model mymodel(uid: username, notes: [string])` instead.
+  - Simple lists can now be defined using simple list syntax
+    - For example, instead of `create model spc.mdl(uid: username, notes: list { type: string })` you will now be able to simply use `create model mymodel(uid: username, notes: [string])` instead.
+    - Similarly, instead of `alter model spc.mdl add notes { type: list { type: string } }` you can use `alter model spc.mdl add notes { type: [string] }`
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ All changes in this project will be noted in this file.
 ### Additions
 
 - Server:
-  - Added `TRUNCATE MODEL` query (and no, I still have no idea why this wasn't present in the first place. There are some things in the universe that
-  no one knows the answer to. This is one of those things.)
-
-  Also note: `TRUNCATE MODEL` is root only right now.
+  - Added `TRUNCATE MODEL` query (and no, I still have no idea why this wasn't present in the first place. There are some things in the universe that no one knows the answer to. This is one of those things.)
+    > Also note: `TRUNCATE MODEL` is root only right now.
+  - Simple lists can now be defined using simple list syntax. For example, instead of `create model mymodel(uid: username, notes: list { type: string })`
+    you will now be able to simply use `create model mymodel(uid: username, notes: [string])` instead.
 
 ### Fixes
 

--- a/server/src/engine/ql/ddl/syn.rs
+++ b/server/src/engine/ql/ddl/syn.rs
@@ -558,7 +558,7 @@ pub fn parse_list_decl_syntax<'a, Qd: QueryData<'a>>(
     ];
     let mut balance = 1;
     let mut ty = None;
-    while state.not_exhausted() && balance != 0 {
+    while state.not_exhausted() && balance != 0 && state.okay() {
         match state.fw_read() {
             Token::Ident(type_id) if ty.is_none() => {
                 // found the inner type

--- a/server/src/engine/ql/ddl/syn.rs
+++ b/server/src/engine/ql/ddl/syn.rs
@@ -259,7 +259,6 @@ pub struct LayerSpec<'a> {
 
 impl<'a> LayerSpec<'a> {
     //// Create a new layer
-    #[cfg(test)]
     pub const fn new(ty: Ident<'a>, props: DictGeneric) -> Self {
         Self { ty, props }
     }
@@ -354,7 +353,6 @@ pub struct FieldSpec<'a> {
 }
 
 impl<'a> FieldSpec<'a> {
-    #[cfg(test)]
     pub fn new(
         field_name: Ident<'a>,
         layers: Vec<LayerSpec<'a>>,
@@ -385,6 +383,16 @@ impl<'a> FieldSpec<'a> {
             (Token::Ident(id), Token![:]) => id,
             _ => return Err(QueryError::QLInvalidSyntax),
         };
+        // see if this is a simple list
+        if state.cursor_rounded_eq(Token![open []]) {
+            state.cursor_ahead();
+            return Ok(FieldSpec::new(
+                *field_name,
+                parse_list_decl_syntax(state)?,
+                is_null,
+                is_primary,
+            ));
+        }
         // layers
         let mut layers = Vec::new();
         rfold_layers(state, &mut layers);
@@ -518,6 +526,54 @@ impl<'a> ExpandedField<'a> {
             }
             _ => Err(QueryError::QLExpectedStatement),
         }
+    }
+}
+
+pub fn parse_list_decl_syntax<'a, Qd: QueryData<'a>>(
+    state: &mut State<'a, Qd>,
+) -> QueryResult<Vec<LayerSpec<'a>>> {
+    /*
+        we are looking at something of the form:
+        [string] or [[string]] and so forth
+
+        the first token has already been validated, so we can be sure that this has atleast one item
+    */
+    let mut layers = vec![
+        LayerSpec::new("unknown".into(), into_dict!()),
+        LayerSpec::new("list".into(), into_dict!()),
+    ];
+    let mut balance = 1;
+    let mut ty = None;
+    while state.not_exhausted() && balance != 0 {
+        match state.fw_read() {
+            Token::Ident(type_id) if ty.is_none() => {
+                // found the inner type
+                ty = Some(LayerSpec::new(*type_id, into_dict!()));
+            }
+            Token![open []] => {
+                // yet anothe nesting. push it in
+                layers.push(LayerSpec::new("list".into(), into_dict!()));
+                balance += 1;
+            }
+            Token![close []] => {
+                balance -= 1;
+            }
+            _ => {
+                // we don't accept anything else here
+                state.poison();
+            }
+        }
+    }
+    state.poison_if_not(balance == 0);
+    state.poison_if_not(ty.is_some());
+    if state.okay() {
+        layers[0] = unsafe {
+            // UNSAFE(@ohsayan): just verified using state
+            ty.unwrap_unchecked()
+        };
+        Ok(layers)
+    } else {
+        Err(QueryError::QLInvalidTypeDefinitionSyntax)
     }
 }
 

--- a/server/src/engine/ql/ddl/syn.rs
+++ b/server/src/engine/ql/ddl/syn.rs
@@ -109,7 +109,13 @@ struct TypeBreakpoint;
 impl<'a> Breakpoint<'a> for TypeBreakpoint {
     const HAS_BREAKPOINT: bool = true;
     fn check_breakpoint(state: DictFoldState, tok: &'a Token<'a>) -> bool {
-        (state == DictFoldState::CB_OR_IDENT) & matches!(tok, Token![type])
+        (state == DictFoldState::CB_OR_IDENT)
+            & (
+                // type decl breakpoint
+                matches!(tok, Token![type]) |
+                // simple list breakpoint
+                matches!(tok, Token![open []])
+            )
     }
 }
 
@@ -439,16 +445,24 @@ impl<'a> ExpandedField<'a> {
         state.cursor_ahead();
         // ignore errors; now attempt a tymeta-like parse
         let mut props = DictGeneric::new();
-        let mut layers = Vec::new();
+        let mut layers = vec![];
         if rfold_tymeta(DictFoldState::CB_OR_IDENT, state, &mut props) {
             // this has layers. fold them; but don't forget the colon
-            if compiler::unlikely(state.exhausted()) {
+            if compiler::unlikely(state.remaining() < 2) {
                 // we need more tokens
                 return Err(QueryError::QLUnexpectedEndOfStatement);
             }
             state.poison_if_not(state.cursor_eq(Token![:]));
             state.cursor_ahead();
-            rfold_layers(state, &mut layers);
+            if state.cursor_eq(Token![open []]) {
+                // simple list syntax
+                state.cursor_ahead();
+                layers = parse_list_decl_syntax(state)?;
+            } else {
+                // not simple list syntax, so continue processing layers
+                layers = vec![];
+                rfold_layers(state, &mut layers);
+            }
             match state.fw_read() {
                 Token![,] => {
                     rfold_dict(DictFoldState::CB_OR_IDENT, state, &mut props);

--- a/server/src/engine/ql/tests/schema_tests.rs
+++ b/server/src/engine/ql/tests/schema_tests.rs
@@ -750,6 +750,59 @@ mod dict_field_syntax {
             )
         );
     }
+    #[sky_macros::test]
+    fn field_syn_simple_list_syntax() {
+        let samples = [
+            (
+                "notes {
+                    nullable: true,
+                    type: [[string]],
+                    jingle_bells: \"snow\"
+                }",
+                ExpandedField::new(
+                    Ident::from("notes"),
+                    vec![
+                        LayerSpec::new(Ident::from("string"), into_dict!()),
+                        LayerSpec::new(Ident::from("list"), into_dict!()),
+                        LayerSpec::new(Ident::from("list"), into_dict!()),
+                    ],
+                    null_dict! {
+                        "nullable" => Lit::new_bool(true),
+                        "jingle_bells" => Lit::new_string("snow".into()),
+                    },
+                ),
+            ),
+            (
+                "notes { type: [[string]] }",
+                ExpandedField::new(
+                    Ident::from("notes"),
+                    vec![
+                        LayerSpec::new(Ident::from("string"), into_dict!()),
+                        LayerSpec::new(Ident::from("list"), into_dict!()),
+                        LayerSpec::new(Ident::from("list"), into_dict!()),
+                    ],
+                    into_dict!(),
+                ),
+            ),
+            (
+                "notes { type: [[string]], }",
+                ExpandedField::new(
+                    Ident::from("notes"),
+                    vec![
+                        LayerSpec::new(Ident::from("string"), into_dict!()),
+                        LayerSpec::new(Ident::from("list"), into_dict!()),
+                        LayerSpec::new(Ident::from("list"), into_dict!()),
+                    ],
+                    into_dict!(),
+                ),
+            ),
+        ];
+        for (sample, expected) in samples {
+            let tok = lex_insecure(sample.as_bytes()).unwrap();
+            let ef = parse_ast_node_full::<ExpandedField>(&tok).unwrap();
+            assert_eq!(ef, expected);
+        }
+    }
 }
 mod alter_model_remove {
     use super::*;

--- a/server/src/engine/ql/tests/schema_tests.rs
+++ b/server/src/engine/ql/tests/schema_tests.rs
@@ -585,7 +585,52 @@ mod schemas {
             |r: CreateModel| assert_eq!(r, ret),
         );
     }
+    #[sky_macros::test]
+    fn simple_list_syntax() {
+        let simple_list_decls = [
+            (
+                "[string]",
+                vec![
+                    LayerSpec::new("string".into(), into_dict!()),
+                    LayerSpec::new("list".into(), into_dict!()),
+                ],
+            ),
+            (
+                "[[string]]",
+                vec![
+                    LayerSpec::new("string".into(), into_dict!()),
+                    LayerSpec::new("list".into(), into_dict!()),
+                    LayerSpec::new("list".into(), into_dict!()),
+                ],
+            ),
+        ];
+        for (list_decl, expected) in simple_list_decls {
+            let query =
+                format!("create model myspace.mymodel(username: string, notes: {list_decl})")
+                    .into_bytes();
+            let tokens = lex_insecure(&query).unwrap();
+            let cm: CreateModel = ast::parse_ast_node_full(&tokens[2..]).unwrap();
+            assert_eq!(
+                cm,
+                CreateModel::new(
+                    ("myspace", "mymodel").into(),
+                    vec![
+                        FieldSpec::new(
+                            "username".into(),
+                            vec![LayerSpec::new("string".into(), into_dict!())],
+                            false,
+                            false
+                        ),
+                        FieldSpec::new("notes".into(), expected, false, false)
+                    ],
+                    into_dict!(),
+                    false,
+                )
+            );
+        }
+    }
 }
+
 mod dict_field_syntax {
     use super::*;
     use crate::engine::ql::{

--- a/server/src/engine/ql/tests/structure_syn.rs
+++ b/server/src/engine/ql/tests/structure_syn.rs
@@ -28,8 +28,12 @@ use {
     super::*,
     crate::engine::{
         data::{lit::Lit, DictGeneric},
-        ql::{ast::parse_ast_node_full, ddl::syn::DictBasic},
+        ql::{
+            ast::parse_ast_node_full,
+            ddl::syn::{self, DictBasic, LayerSpec},
+        },
     },
+    ast::State,
 };
 
 macro_rules! fold_dict {
@@ -229,6 +233,24 @@ mod dict {
         });
     }
 }
+
+#[sky_macros::test]
+fn list_syn_parse() {
+    let tokens = b"[[[string]]]";
+    let tokens = lex_insecure(tokens).unwrap();
+    let mut state = State::new_inplace(&tokens[1..]);
+    let lspec = syn::parse_list_decl_syntax(&mut state).unwrap();
+    assert_eq!(
+        lspec,
+        vec![
+            LayerSpec::new("string".into(), into_dict!()),
+            LayerSpec::new("list".into(), into_dict!()),
+            LayerSpec::new("list".into(), into_dict!()),
+            LayerSpec::new("list".into(), into_dict!()),
+        ]
+    )
+}
+
 mod null_dict_tests {
     use super::*;
     mod dict {

--- a/server/src/engine/ql/tests/structure_syn.rs
+++ b/server/src/engine/ql/tests/structure_syn.rs
@@ -28,6 +28,7 @@ use {
     super::*,
     crate::engine::{
         data::{lit::Lit, DictGeneric},
+        error::QueryError,
         ql::{
             ast::parse_ast_node_full,
             ddl::syn::{self, DictBasic, LayerSpec},
@@ -249,6 +250,19 @@ fn list_syn_parse() {
             LayerSpec::new("list".into(), into_dict!()),
         ]
     )
+}
+
+#[sky_macros::test]
+fn list_syn_parse_fail() {
+    let failure_cases = ["[string", "[[string]", "[string string]", "]"];
+    for failure_case in failure_cases {
+        let tokens = lex_insecure(failure_case.as_bytes()).unwrap();
+        let mut state = State::new_inplace(&tokens[1..]);
+        assert_eq!(
+            syn::parse_list_decl_syntax(&mut state).unwrap_err(),
+            QueryError::QLInvalidTypeDefinitionSyntax
+        );
+    }
 }
 
 mod null_dict_tests {


### PR DESCRIPTION
**Before:**
```sql
CREATE MODEL myspace.mymodel(
    username: string,
    password: string,
    followers: list { type: uint64 }
)
ALTER MODEL myspace.mymodel ADD following { type: list { type: uint64 } }
```

**After:**
```sql
CREATE MODEL myspace.mymodel(username: string, password: string, followers: [uint64])
ALTER MODEL myspace.mymodel ADD following { type: [uint64] }
```

Do note that this change is fully backwards compatible as we will continue to support the advanced type definition syntax.

---
✔️ By submitting this pull request, I agree to the CLA at: https://cla.skytable.io/skytable/skytable
