### PR TITLE
docs: add CONTRIBUTING guide to help new contributors

### DIFF
--- a/CONTRIBUTING_TO.md
+++ b/CONTRIBUTING_TO.md
@@ -1,0 +1,31 @@
+# Contributing to Skytable
+
+Thank you for your interest in contributing!  
+
+Here are some simple guidelines to help you get started:
+
+## Getting started
+
+1. Fork the repository.  
+2. Create a new branch for your changes.  
+3. Make your changes (code, documentation, examples).  
+4. Commit your changes with a clear commit message.  
+5. Push your branch to your fork.  
+6. Open a Pull Request (PR) describing your changes and why they are needed.
+
+## Pull Request guidelines
+
+- Keep PRs small and focused — one feature/bugfix per PR.  
+- Write a clear, descriptive title and description for your PR.  
+- If applicable, add tests or update documentation to reflect your changes.  
+- Be courteous — maintainers review PRs voluntarily, so a respectful and coherent PR improves chances of review and merge.  
+
+## Code style & formatting
+
+Follow the existing code style. If in doubt, read existing code to match formatting and conventions.  
+
+## Reporting issues or bugs
+
+If you find a bug or want to propose a feature, please open an issue first — describe clearly what you found, how to reproduce it, and why your change helps.  
+
+Thanks for contributing! 🙏


### PR DESCRIPTION
## What

This PR adds a CONTRIBUTING.md file to the repository to provide basic guidelines for contributors.

## Why

Having a CONTRIBUTING.md helps new contributors know how to contribute — how to fork, create branches, name commits/PRs, and raise pull requests. It makes the onboarding process smoother and encourages more community contributions.

## Changes

- Added CONTRIBUTING.md with initial guidance and instructions.
